### PR TITLE
perf(web): make the locations map editor responsive

### DIFF
--- a/apps/api/src/locations/locations.service.ts
+++ b/apps/api/src/locations/locations.service.ts
@@ -650,7 +650,7 @@ export class LocationsService {
                 display_name: region.displayName,
                 geometry: region.geometry as unknown as JsonObject,
                 z_order: region.zOrder,
-                search_aliases: [...region.searchAliases],
+                search_aliases: JSON.stringify(region.searchAliases),
                 status: region.status,
               })),
             )

--- a/apps/api/src/seed/catalogue.ts
+++ b/apps/api/src/seed/catalogue.ts
@@ -238,7 +238,9 @@ const groups: readonly CatalogueGroup[] = [
 ] as const;
 
 function eanBarcode(index: number): string {
-  const body = String(5_010_000_000 + index * 7_919).padStart(12, "0").slice(-12);
+  const body = String(5_010_000_000 + index * 7_919)
+    .padStart(12, "0")
+    .slice(-12);
   let total = 0;
 
   for (let position = 0; position < body.length; position += 1) {

--- a/apps/api/src/seed/seed.ts
+++ b/apps/api/src/seed/seed.ts
@@ -190,7 +190,7 @@ const seed = async (): Promise<void> => {
             display_name: "Main store north",
             geometry: { kind: "Rectangle", x: 0.05, y: 0.08, width: 0.4, height: 0.32 },
             z_order: 1,
-            search_aliases: ["north cache"],
+            search_aliases: JSON.stringify(["north cache"]),
             status: "Active",
           },
           {
@@ -209,7 +209,7 @@ const seed = async (): Promise<void> => {
               ],
             },
             z_order: 2,
-            search_aliases: ["south cache"],
+            search_aliases: JSON.stringify(["south cache"]),
             status: "Active",
           },
           {
@@ -220,7 +220,7 @@ const seed = async (): Promise<void> => {
             display_name: "Main store centre",
             geometry: { kind: "Rectangle", x: 0.2, y: 0.55, width: 0.5, height: 0.3 },
             z_order: 3,
-            search_aliases: ["centre cache"],
+            search_aliases: JSON.stringify(["centre cache"]),
             status: "Active",
           },
         ])

--- a/apps/api/test/api.db.spec.ts
+++ b/apps/api/test/api.db.spec.ts
@@ -132,9 +132,25 @@ async function seedItem(reference: string): Promise<string> {
 async function seedLocation(code: string): Promise<string> {
   const id = randomUUID();
 
+  /*
+   * Mirrors what POST /locations writes. The hierarchy columns are not optional
+   * in practice: `general_fulfilment_enabled` defaults to false, and a store
+   * that is not fulfilment-enabled is excluded from availability, so a fixture
+   * that omits them holds stock nothing can see.
+   */
   await schema()
     .insertInto("locations")
-    .values({ id, code, name: `${code} store`, kind: "Store", job_id: null, is_active: true })
+    .values({
+      id,
+      code,
+      name: `${code} store`,
+      kind: "Store",
+      job_id: null,
+      is_active: true,
+      node_kind: "CustomSection",
+      operational_kind: "Storage",
+      general_fulfilment_enabled: true,
+    })
     .execute();
 
   return id;

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
         import.meta.dirname,
         "../../packages/contracts/src/index.ts",
       ),
+      "@stockcontrol/module-locations": path.resolve(
+        import.meta.dirname,
+        "../../packages/modules/locations/src/index.ts",
+      ),
       "@stockcontrol/module-system": path.resolve(
         import.meta.dirname,
         "../../packages/modules/system/src/index.ts",

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -30,6 +30,10 @@ export default defineConfig({
         import.meta.dirname,
         "../../packages/contracts/src/index.ts",
       ),
+      "@stockcontrol/module-locations": path.resolve(
+        import.meta.dirname,
+        "../../packages/modules/locations/src/index.ts",
+      ),
       "@stockcontrol/module-system": path.resolve(
         import.meta.dirname,
         "../../packages/modules/system/src/index.ts",

--- a/apps/e2e/tests/demo-journey.spec.ts
+++ b/apps/e2e/tests/demo-journey.spec.ts
@@ -335,7 +335,12 @@ test("a scanned item opens after signing in, on a phone", async ({ page, context
   /* The QR code encodes this page's own address, so that is what a camera opens. */
   await context.clearCookies();
   await page.goto(itemUrl);
-  await expect(page).toHaveURL(/\/sign-in$/);
+  /*
+   * The sign-in URL carries the item along. Arriving from a camera is a full
+   * page load, so router state is gone by this point and the query string is
+   * what brings the visitor back to the record they scanned.
+   */
+  await expect(page).toHaveURL(/\/sign-in\?next=/u);
 
   await page.getByLabel("Work email").fill(ENGINEER.email);
   await page.getByLabel("Password", { exact: true }).fill(ENGINEER.password);

--- a/apps/e2e/tests/demo-journey.spec.ts
+++ b/apps/e2e/tests/demo-journey.spec.ts
@@ -95,7 +95,7 @@ test("an anonymous visitor is sent to sign in", async ({ page }) => {
   await page.goto("/inventory");
 
   await expect(page).toHaveURL(/\/sign-in$/);
-  await expect(page.getByRole("heading", { name: "Welcome back" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Sign in" })).toBeVisible();
 });
 
 test("wrong details are refused without saying which detail was wrong", async ({ page }) => {

--- a/apps/web/src/app/Accessibility.test.tsx
+++ b/apps/web/src/app/Accessibility.test.tsx
@@ -72,7 +72,7 @@ describe("StockControl automated accessibility checks", () => {
       </StockControlProviders>,
     );
 
-    await screen.findByRole("heading", { name: "Welcome back" });
+    await screen.findByRole("heading", { name: "Sign in" });
     await expectNoAccessibilityViolations(container);
   });
 

--- a/apps/web/src/app/Accessibility.test.tsx
+++ b/apps/web/src/app/Accessibility.test.tsx
@@ -91,4 +91,32 @@ describe("StockControl automated accessibility checks", () => {
     await screen.findByRole("heading", { name: /Good to see you/u });
     await expectNoAccessibilityViolations(container);
   });
+
+  it("has no detectable violations on the building map", async () => {
+    const { container } = render(
+      <StockControlProviders
+        authClient={new AccessibilityAuthClient(adminSession)}
+        apiClient={createFakeApiClient()}
+      >
+        <MemoryRouter initialEntries={["/locations"]}>
+          <AppRoutes />
+        </MemoryRouter>
+      </StockControlProviders>,
+    );
+
+    /* Generous: this route is code-split, so the chunk resolves before the map does. */
+    const canvas = await screen.findByRole(
+      "application",
+      { name: /Main warehouse map/u },
+      { timeout: 5000 },
+    );
+
+    /*
+     * The canvas is a single tab stop that moves an active descendant, rather
+     * than one tab stop per region plus four per selection handle.
+     */
+    expect(canvas).toHaveAttribute("tabindex", "0");
+    expect(container.querySelectorAll("svg [tabindex]")).toHaveLength(0);
+    await expectNoAccessibilityViolations(container);
+  });
 });

--- a/apps/web/src/app/AppRoutes.test.tsx
+++ b/apps/web/src/app/AppRoutes.test.tsx
@@ -103,7 +103,7 @@ describe("StockControl application routes", () => {
   it("redirects an anonymous protected-route visit to sign in", async () => {
     renderRoute("/inventory");
 
-    expect(await screen.findByRole("heading", { name: "Welcome back" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Sign in" })).toBeInTheDocument();
     expect(screen.getByLabelText("Work email")).toHaveAttribute("autocomplete", "email");
     expect(screen.getByLabelText("Password")).toHaveAttribute("autocomplete", "current-password");
   });

--- a/apps/web/src/app/AppRoutes.test.tsx
+++ b/apps/web/src/app/AppRoutes.test.tsx
@@ -179,6 +179,34 @@ describe("StockControl application routes", () => {
     ).toBeInTheDocument();
   });
 
+  /*
+   * Arriving from a camera is a full page load, so there is no router history
+   * state to carry the destination — only the URL. This is the case the demo
+   * journey walks, and the one that used to bounce to the dashboard.
+   */
+  it("returns to the record when only the URL remembers it", async () => {
+    renderRoute("/sign-in?next=%2Finventory%2Fitem-1");
+
+    await completeValidSignIn();
+
+    expect(
+      await screen.findByRole("heading", { name: /M6 × 30 mm zinc-plated hex bolt/u }),
+    ).toBeInTheDocument();
+  });
+
+  /*
+   * Signing in flips the auth status while the sign-in page is running its own
+   * redirect. Both sides have to choose the same destination or they race, and
+   * the visitor lands wherever the later navigation happened to point.
+   */
+  it("sends an already-signed-in visitor on /sign-in to the record, not the dashboard", async () => {
+    renderRoute("/sign-in?next=%2Finventory%2Fitem-1", new FakeAuthClient(userForRole("Office")));
+
+    expect(
+      await screen.findByRole("heading", { name: /M6 × 30 mm zinc-plated hex bolt/u }),
+    ).toBeInTheDocument();
+  });
+
   it.each([
     null,
     "https://malicious.example/steal",

--- a/apps/web/src/app/AppRoutes.tsx
+++ b/apps/web/src/app/AppRoutes.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import { Suspense, lazy, type ReactElement } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 
 import { useAuth } from "../auth/AuthContext";
@@ -16,9 +16,16 @@ import { SignInPage } from "../pages/SignInPage";
 import { TransactionsPage } from "../pages/TransactionsPage";
 import { UserDetailPage } from "../pages/UserDetailPage";
 import { UsersPage } from "../pages/UsersPage";
-import { LocationsPage } from "../pages/LocationsPage";
 import { RouteErrorBoundary } from "./ErrorBoundaries";
 import { RouteTransitionManager } from "./RouteTransitionManager";
+
+/*
+ * The map editor and its twenty icon modules are worth their own chunk: no other
+ * screen needs them, and most sessions never open this one.
+ */
+const LocationsPage = lazy(async () => ({
+  default: (await import("../pages/LocationsPage")).LocationsPage,
+}));
 
 interface GuardedProps {
   readonly path: string;
@@ -87,7 +94,14 @@ export function AppRoutes(): ReactElement {
               }
             />
             <Route path="/transactions" element={<TransactionsPage />} />
-            <Route path="/locations" element={<LocationsPage />} />
+            <Route
+              path="/locations"
+              element={
+                <Suspense fallback={<LoadingPage />}>
+                  <LocationsPage />
+                </Suspense>
+              }
+            />
             <Route
               path="/team"
               element={

--- a/apps/web/src/auth/RouteGuards.tsx
+++ b/apps/web/src/auth/RouteGuards.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement, ReactNode } from "react";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { FullPageLoading } from "../components/RouteStates";
+import { getRedirectPath, signInPathFor } from "../pages/SignInPage";
 import { useAuth } from "./AuthContext";
 
 interface SignedOutOnlyProps {
@@ -18,7 +19,7 @@ export function RequireAuthentication(): ReactElement {
   if (status !== "authenticated") {
     return (
       <Navigate
-        to="/sign-in"
+        to={signInPathFor(`${location.pathname}${location.search}${location.hash}`)}
         replace
         state={{ from: `${location.pathname}${location.search}${location.hash}` }}
       />
@@ -30,13 +31,21 @@ export function RequireAuthentication(): ReactElement {
 
 export function SignedOutOnly({ children }: SignedOutOnlyProps): ReactElement {
   const { status } = useAuth();
+  const location = useLocation();
 
   if (status === "checking") {
     return <FullPageLoading />;
   }
 
+  /*
+   * The same destination the sign-in page itself picks. Signing in flips the
+   * status here at the moment the page runs its own redirect, so if this sent
+   * everyone to the dashboard the two would race — and a visitor who arrived
+   * from a scanned QR code would be bounced off the item they asked for,
+   * intermittently, depending on which navigation landed last.
+   */
   if (status === "authenticated") {
-    return <Navigate to="/dashboard" replace />;
+    return <Navigate to={getRedirectPath(location.state, location.search)} replace />;
   }
 
   return <>{children}</>;

--- a/apps/web/src/components/Brand.tsx
+++ b/apps/web/src/components/Brand.tsx
@@ -22,7 +22,9 @@ export function Brand({ inverse = false, compact = false }: BrandProps): ReactEl
     >
       <Box
         component="img"
-        src={inverse ? "/christy-plumbing-logo-white-2025.png" : "/christy-plumbing-main-logo-2025.png"}
+        src={
+          inverse ? "/christy-plumbing-logo-white-2025.png" : "/christy-plumbing-main-logo-2025.png"
+        }
         alt="Christy Plumbing & Heating"
         sx={{
           position: "absolute",

--- a/apps/web/src/hooks/use-debounced-value.ts
+++ b/apps/web/src/hooks/use-debounced-value.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Holds a value back until it stops changing.
+ *
+ * `useResource` refetches whenever its loader identity changes, so feeding it a
+ * raw input value issues one request per keystroke. Location search is
+ * particularly expensive on the server, which walks every map's regions.
+ */
+export function useDebouncedValue<Value>(value: Value, delayMs: number): Value {
+  const [settled, setSettled] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSettled(value);
+    }, delayMs);
+
+    return (): void => {
+      clearTimeout(timer);
+    };
+  }, [value, delayMs]);
+
+  return settled;
+}

--- a/apps/web/src/pages/ItemDetailPage.tsx
+++ b/apps/web/src/pages/ItemDetailPage.tsx
@@ -270,7 +270,11 @@ export function ItemDetailPage(): ReactElement {
                     Print label
                   </Button>
                 </Box>
-                <Box className="print-only" sx={{ display: "none" }} aria-label="Printable item label">
+                <Box
+                  className="print-only"
+                  sx={{ display: "none" }}
+                  aria-label="Printable item label"
+                >
                   <Typography component="p" className="print-name">
                     {data.name}
                   </Typography>

--- a/apps/web/src/pages/LocationsPage.tsx
+++ b/apps/web/src/pages/LocationsPage.tsx
@@ -1,27 +1,5 @@
 import AddRounded from "@mui/icons-material/AddRounded";
-import AccountTreeRounded from "@mui/icons-material/AccountTreeRounded";
-import BusinessRounded from "@mui/icons-material/BusinessRounded";
-import ArchiveRounded from "@mui/icons-material/ArchiveRounded";
-import ArrowDownwardRounded from "@mui/icons-material/ArrowDownwardRounded";
-import ArrowUpwardRounded from "@mui/icons-material/ArrowUpwardRounded";
-import ChevronRightRounded from "@mui/icons-material/ChevronRightRounded";
-import CheckCircleRounded from "@mui/icons-material/CheckCircleRounded";
-import CloseRounded from "@mui/icons-material/CloseRounded";
-import DeleteOutlineRounded from "@mui/icons-material/DeleteOutlineRounded";
-import EditRounded from "@mui/icons-material/EditRounded";
-import ExpandMoreRounded from "@mui/icons-material/ExpandMoreRounded";
-import FitScreenRounded from "@mui/icons-material/FitScreenRounded";
-import FolderRounded from "@mui/icons-material/FolderRounded";
-import GridOnRounded from "@mui/icons-material/GridOnRounded";
 import MapRounded from "@mui/icons-material/MapRounded";
-import PanToolRounded from "@mui/icons-material/PanToolRounded";
-import PolylineRounded from "@mui/icons-material/PolylineRounded";
-import RemoveCircleOutlineRounded from "@mui/icons-material/RemoveCircleOutlineRounded";
-import SearchRounded from "@mui/icons-material/SearchRounded";
-import UploadFileRounded from "@mui/icons-material/UploadFileRounded";
-import WarningAmberRounded from "@mui/icons-material/WarningAmberRounded";
-import ZoomInRounded from "@mui/icons-material/ZoomInRounded";
-import ZoomOutRounded from "@mui/icons-material/ZoomOutRounded";
 import {
   Alert,
   Box,
@@ -30,15 +8,9 @@ import {
   FormControl,
   IconButton,
   InputLabel,
-  List,
-  ListItemButton,
-  ListItemText,
   MenuItem,
   Select,
   Stack,
-  TextField,
-  ToggleButton,
-  ToggleButtonGroup,
   Tooltip,
   Typography,
 } from "@mui/material";
@@ -49,276 +21,40 @@ import {
   useReducer,
   useRef,
   useState,
-  type PointerEvent,
   type ReactElement,
 } from "react";
 import type {
+  CreateHierarchyNodeRequest,
   HierarchyNodeView,
+  LocationSearchResult,
   MapGeometry,
-  MapRegionInput,
-  MapRegionView,
-  MapSnapshot,
 } from "@stockcontrol/contracts";
 
 import { ApiError } from "../api/ApiClient";
 import { useApi, useResource } from "../api/ApiContext";
 import { useAuth } from "../auth/AuthContext";
+import { useDebouncedValue } from "../hooks/use-debounced-value";
+import { mapBorder } from "./locations/constants";
+import {
+  editorReducer,
+  flattenHierarchy,
+  initialEditor,
+  toInputs,
+  type EditorMode,
+  type RegionChanges,
+} from "./locations/editor-state";
+import { HierarchyPanel } from "./locations/HierarchyPanel";
+import { MapWorkspace } from "./locations/MapWorkspace";
+import { RegionInspector } from "./locations/RegionInspector";
 
-type EditorMode = "select" | "rectangle" | "polygon" | "pan";
-type DraftRegion = Omit<MapRegionView, "id"> & { readonly id?: string };
-interface EditorState {
-  readonly persisted: MapSnapshot | null;
-  readonly draft: MapSnapshot | null;
-  readonly selectedRegionId: string | null;
-  readonly mode: EditorMode;
-  readonly zoom: number;
-  readonly drawingPoints: readonly { readonly x: number; readonly y: number }[];
-  readonly rectangleStart: { readonly x: number; readonly y: number } | null;
-  readonly dirty: boolean;
-}
-type EditorAction =
-  | { readonly type: "load"; readonly map: MapSnapshot }
-  | { readonly type: "select"; readonly id: string | null }
-  | { readonly type: "mode"; readonly mode: EditorMode }
-  | { readonly type: "zoom"; readonly amount: number }
-  | { readonly type: "revert" }
-  | {
-      readonly type: "points";
-      readonly points: readonly { readonly x: number; readonly y: number }[];
-    }
-  | {
-      readonly type: "rectangle-start";
-      readonly point: { readonly x: number; readonly y: number } | null;
-    }
-  | { readonly type: "add"; readonly region: DraftRegion }
-  | { readonly type: "update"; readonly region: DraftRegion }
-  | { readonly type: "saved"; readonly map: MapSnapshot };
+const SEARCH_DEBOUNCE_MS = 250;
 
-const initialEditor: EditorState = {
-  persisted: null,
-  draft: null,
-  selectedRegionId: null,
-  mode: "select",
-  zoom: 1,
-  drawingPoints: [],
-  rectangleStart: null,
-  dirty: false,
-};
-
-function editorReducer(state: EditorState, action: EditorAction): EditorState {
-  if (action.type === "load")
-    return {
-      ...state,
-      persisted: action.map,
-      draft: action.map,
-      dirty: false,
-      selectedRegionId: null,
-      drawingPoints: [],
-      rectangleStart: null,
-    };
-  if (action.type === "saved")
-    return {
-      ...state,
-      persisted: action.map,
-      draft: action.map,
-      dirty: false,
-      drawingPoints: [],
-      rectangleStart: null,
-    };
-  if (action.type === "select") return { ...state, selectedRegionId: action.id };
-  if (action.type === "mode")
-    return { ...state, mode: action.mode, drawingPoints: [], rectangleStart: null };
-  if (action.type === "zoom")
-    return { ...state, zoom: Math.max(0.5, Math.min(4, state.zoom + action.amount)) };
-  if (action.type === "revert")
-    return {
-      ...state,
-      draft: state.persisted,
-      dirty: false,
-      selectedRegionId: null,
-      drawingPoints: [],
-      rectangleStart: null,
-    };
-  if (action.type === "points") return { ...state, drawingPoints: action.points };
-  if (action.type === "rectangle-start") return { ...state, rectangleStart: action.point };
-  if (action.type === "add" && state.draft !== null) {
-    const id = action.region.id ?? `draft-${String(Date.now())}`;
-    return {
-      ...state,
-      draft: { ...state.draft, regions: [...state.draft.regions, { ...action.region, id }] },
-      selectedRegionId: id,
-      dirty: true,
-      mode: "select",
-    };
-  }
-  if (action.type === "update" && state.draft !== null) {
-    const { id: ignoredId, ...changes } = action.region;
-    void ignoredId;
-    return {
-      ...state,
-      draft: {
-        ...state.draft,
-        regions: state.draft.regions.map((region) =>
-          region.id === action.region.id ? { ...region, ...changes } : region,
-        ),
-      },
-      dirty: true,
-    };
-  }
-  return state;
-}
-
-const clamp = (value: number): number => Math.max(0, Math.min(1, value));
-const pointFromEvent = (
-  event: PointerEvent<SVGSVGElement>,
-): { readonly x: number; readonly y: number } => {
-  const bounds = event.currentTarget.getBoundingClientRect();
-  return {
-    x: clamp((event.clientX - bounds.left) / bounds.width),
-    y: clamp((event.clientY - bounds.top) / bounds.height),
-  };
-};
-const pointFromClient = (
-  clientX: number,
-  clientY: number,
-  canvas: SVGSVGElement,
-): { readonly x: number; readonly y: number } => {
-  const bounds = canvas.getBoundingClientRect();
-  return {
-    x: clamp((clientX - bounds.left) / bounds.width),
-    y: clamp((clientY - bounds.top) / bounds.height),
-  };
-};
-const geometryString = (geometry: MapGeometry): string =>
-  geometry.kind === "Rectangle"
-    ? `${String(geometry.x * 100)},${String(geometry.y * 100)} ${String(geometry.width * 100)},${String(geometry.height * 100)}`
-    : geometry.points.map((point) => `${String(point.x * 100)},${String(point.y * 100)}`).join(" ");
-const moveGeometry = (geometry: MapGeometry, dx: number, dy: number): MapGeometry => {
-  if (geometry.kind === "Rectangle")
-    return {
-      ...geometry,
-      x: Math.min(1 - geometry.width, Math.max(0, geometry.x + dx)),
-      y: Math.min(1 - geometry.height, Math.max(0, geometry.y + dy)),
-    };
-  return {
-    ...geometry,
-    points: geometry.points.map((point) => ({ x: clamp(point.x + dx), y: clamp(point.y + dy) })),
-  };
-};
-const resizeRectangle = (
-  geometry: Extract<MapGeometry, { readonly kind: "Rectangle" }>,
-  handle: "nw" | "ne" | "sw" | "se",
-  point: { readonly x: number; readonly y: number },
-): MapGeometry => {
-  const right = geometry.x + geometry.width;
-  const bottom = geometry.y + geometry.height;
-  const left = handle.includes("w") ? Math.min(point.x, right - 0.02) : geometry.x;
-  const top = handle.includes("n") ? Math.min(point.y, bottom - 0.02) : geometry.y;
-  const nextRight = handle.includes("e") ? Math.max(point.x, left + 0.02) : right;
-  const nextBottom = handle.includes("s") ? Math.max(point.y, top + 0.02) : bottom;
-  const nextLeft = clamp(left);
-  const boundedTop = clamp(top);
-  const boundedRight = Math.min(1, Math.max(nextLeft + 0.02, nextRight));
-  const boundedBottom = Math.min(1, Math.max(boundedTop + 0.02, nextBottom));
-  return {
-    kind: "Rectangle",
-    x: nextLeft,
-    y: boundedTop,
-    width: boundedRight - nextLeft,
-    height: boundedBottom - boundedTop,
-  };
-};
-
-type CanvasInteraction =
-  | {
-      readonly kind: "move";
-      readonly regionId: string;
-      readonly startPoint: { readonly x: number; readonly y: number };
-      readonly geometry: MapGeometry;
-    }
-  | {
-      readonly kind: "resize";
-      readonly regionId: string;
-      readonly handle: "nw" | "ne" | "sw" | "se";
-      readonly geometry: Extract<MapGeometry, { readonly kind: "Rectangle" }>;
-    };
-const toInputs = (map: MapSnapshot): readonly MapRegionInput[] =>
-  map.regions.map((region) => ({
-    ...(region.id.startsWith("draft-") ? {} : { id: region.id }),
-    displayName: region.displayName,
-    hierarchyNodeId: region.hierarchyNodeId,
-    parentRegionId: region.parentRegionId,
-    geometry: region.geometry,
-    zOrder: region.zOrder,
-    searchAliases: region.searchAliases,
-    status: region.status,
-  }));
-
-const flattenHierarchy = (
-  nodes: readonly MapSnapshot["hierarchy"][number][],
-): readonly MapSnapshot["hierarchy"][number][] =>
-  nodes.flatMap((node) => [node, ...flattenHierarchy(node.children)]);
-
-const fileAsBase64 = (file: File): Promise<string> =>
-  new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.addEventListener("load", () => {
-      const value = typeof reader.result === "string" ? reader.result : "";
-      resolve(value.split(",", 2)[1] ?? "");
-    });
-    reader.addEventListener("error", () =>
-      reject(reader.error ?? new Error("File could not be read.")),
-    );
-    reader.readAsDataURL(file);
-  });
-
-function ToolbarButton({
-  label,
-  onClick,
-  children,
-}: {
-  readonly label: string;
-  readonly onClick: () => void;
-  readonly children: ReactElement;
-}): ReactElement {
-  return (
-    <Tooltip title={label}>
-      <IconButton aria-label={label} onClick={onClick} size="small">
-        {children}
-      </IconButton>
-    </Tooltip>
-  );
-}
-
-function HierarchyIcon({
-  nodeKind,
-}: {
-  readonly nodeKind: HierarchyNodeView["nodeKind"];
-}): ReactElement {
-  if (nodeKind === "Branch") return <AccountTreeRounded fontSize="small" />;
-  if (nodeKind === "Building") return <BusinessRounded fontSize="small" />;
-  return <FolderRounded fontSize="small" />;
-}
-
-function StockStatusIcon({ status }: { readonly status: string }): ReactElement {
-  if (status === "Available") return <CheckCircleRounded fontSize="small" />;
-  if (status === "LowStock") return <WarningAmberRounded fontSize="small" />;
-  if (status === "Archived") return <ArchiveRounded fontSize="small" />;
-  return <RemoveCircleOutlineRounded fontSize="small" />;
-}
-
-const modeLabel = (mode: EditorMode): string => {
-  if (mode === "rectangle") return "Rectangle tool";
-  if (mode === "polygon") return "Polygon tool";
-  if (mode === "pan") return "Pan tool";
-  return "Select tool";
-};
-
-const geometrySummary = (geometry: MapGeometry): string =>
-  geometry.kind === "Rectangle"
-    ? `Rectangle · ${String(Math.round(geometry.width * 100))}% × ${String(Math.round(geometry.height * 100))}%`
-    : `Polygon · ${String(geometry.points.length)} points`;
-
+/**
+ * The locations screen: hierarchy on the left, building map in the middle,
+ * region details on the right. This component only loads data and owns the
+ * committed editor state — pan, zoom and in-flight drag geometry live under
+ * `./locations`, which is what keeps a drag from re-rendering the page.
+ */
 export function LocationsPage(): ReactElement {
   const api = useApi();
   const { user } = useAuth();
@@ -326,35 +62,27 @@ export function LocationsPage(): ReactElement {
   const [buildingId, setBuildingId] = useState<string | null>(null);
   const [editor, dispatch] = useReducer(editorReducer, initialEditor);
   const [query, setQuery] = useState("");
-  const [newNodeName, setNewNodeName] = useState("");
-  const [newNodeCode, setNewNodeCode] = useState("");
-  const [newNodeKind, setNewNodeKind] = useState<
-    "Building" | "Area" | "Aisle" | "Shelf" | "Bin" | "CustomSection"
-  >("Area");
-  const [newNodeParentId, setNewNodeParentId] = useState<string | null>(null);
-  const [selectedHierarchyNodeId, setSelectedHierarchyNodeId] = useState<string | null>(null);
-  const [hierarchyName, setHierarchyName] = useState("");
-  const [collapsedHierarchyIds, setCollapsedHierarchyIds] = useState<ReadonlySet<string>>(
-    new Set(),
-  );
+  const debouncedQuery = useDebouncedValue(query, SEARCH_DEBOUNCE_MS);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [collapsedIds, setCollapsedIds] = useState<ReadonlySet<string>>(new Set());
   const [inspectorOpen, setInspectorOpen] = useState(false);
-  const [focusedId, setFocusedId] = useState<string | null>(null);
+  const [pendingFocusRegionId, setPendingFocusRegionId] = useState<string | null>(null);
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const [conflict, setConflict] = useState(false);
-  const fileInput = useRef<HTMLInputElement>(null);
-  const canvasRef = useRef<SVGSVGElement>(null);
-  const interaction = useRef<CanvasInteraction | null>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+
   const locations = useResource(
     useCallback(
       (signal: AbortSignal) => Promise.all([api.getLocationTree(signal), api.listMaps(signal)]),
       [api],
     ),
   );
-  const buildings = locations.data?.[0].buildings ?? [];
   const maps = useMemo(() => locations.data?.[1] ?? [], [locations.data]);
+  const buildings = useMemo(() => locations.data?.[0].buildings ?? [], [locations.data]);
   const selectedBuildingId = buildingId ?? buildings[0]?.id ?? null;
-  const persistedMapId = editor.persisted === null ? null : editor.persisted.id;
-  const persistedRevision = editor.persisted === null ? -1 : editor.persisted.revision;
+  const persistedMapId = editor.persisted?.id ?? null;
+  const persistedRevision = editor.persisted?.revision ?? -1;
+
   const mapResource = useResource(
     useCallback(
       (signal: AbortSignal) =>
@@ -369,8 +97,10 @@ export function LocationsPage(): ReactElement {
   const searchResource = useResource(
     useCallback(
       (signal: AbortSignal) =>
-        query.trim().length < 1 ? Promise.resolve([]) : api.searchLocations(query, signal),
-      [api, query],
+        debouncedQuery.trim().length < 2
+          ? Promise.resolve([])
+          : api.searchLocations(debouncedQuery, signal),
+      [api, debouncedQuery],
     ),
   );
 
@@ -381,392 +111,276 @@ export function LocationsPage(): ReactElement {
     )
       dispatch({ type: "load", map: mapResource.data });
   }, [mapResource.data, persistedMapId, persistedRevision]);
+
+  /*
+   * Applies a search hit once its building's map has arrived. Keyed on the map
+   * rather than the draft: the old effect re-ran on every draft change, adding a
+   * render to every frame of a drag.
+   */
   useEffect(() => {
-    if (
-      focusedId !== null &&
-      editor.draft !== null &&
-      editor.draft.regions.some((region) => region.id === focusedId)
-    )
-      dispatch({ type: "select", id: focusedId });
-  }, [editor.draft, focusedId]);
-  const selectedRegion =
-    editor.draft?.regions.find((region) => region.id === editor.selectedRegionId) ?? null;
-  const showInspector = inspectorOpen || selectedRegion !== null;
-  const hierarchyOptions =
-    editor.draft !== null
-      ? flattenHierarchy(editor.draft.hierarchy)
-      : locations.data === undefined
-        ? []
-        : flattenHierarchy([locations.data[0].root]);
-  const branchId = locations.data?.[0].root.id ?? null;
-  const defaultParentId =
-    newNodeParentId ?? (newNodeKind === "Building" ? branchId : selectedBuildingId);
-  const selectedHierarchyNode = hierarchyOptions.find(
-    (node) => node.id === selectedHierarchyNodeId,
+    if (pendingFocusRegionId === null) return;
+    dispatch({ type: "select", id: pendingFocusRegionId });
+  }, [persistedMapId, pendingFocusRegionId]);
+
+  const draft = editor.draft;
+  const regions = useMemo(() => draft?.regions ?? [], [draft]);
+  const selectedRegion = useMemo(
+    () => regions.find((region) => region.id === editor.selectedRegionId) ?? null,
+    [regions, editor.selectedRegionId],
   );
-  const renderHierarchy = (
-    nodes: readonly HierarchyNodeView[],
-    depth = 0,
-  ): readonly ReactElement[] =>
-    nodes.flatMap((node) => [
-      <ListItemButton
-        key={node.id}
-        selected={selectedHierarchyNodeId === node.id}
-        aria-selected={selectedHierarchyNodeId === node.id}
-        sx={{
-          position: "relative",
-          display: "grid",
-          gridTemplateColumns: "20px 24px minmax(0, 1fr)",
-          alignItems: "center",
-          gap: 0.5,
-          minHeight: 48,
-          pl: 1 + depth * 2,
-          pr: 1,
-          borderRadius: 1,
-          "&:hover": { bgcolor: "#F3F6FB" },
-          "&.Mui-selected": {
-            bgcolor: "#E8EEF9",
-            boxShadow: "inset 3px 0 0 #00309D",
-            "&:hover": { bgcolor: "#E8EEF9" },
-          },
-        }}
-        onClick={() => {
-          setSelectedHierarchyNodeId(node.id);
-          setHierarchyName(node.name);
-          if (node.nodeKind === "Building") setBuildingId(node.id);
-        }}
-      >
-        {node.children.length > 0 ? (
-          <IconButton
-            size="small"
-            aria-label={`${collapsedHierarchyIds.has(node.id) ? "Expand" : "Collapse"} ${node.name}`}
-            aria-expanded={!collapsedHierarchyIds.has(node.id)}
-            onClick={(event) => {
-              event.stopPropagation();
-              setCollapsedHierarchyIds((current) => {
-                const next = new Set(current);
-                if (next.has(node.id)) next.delete(node.id);
-                else next.add(node.id);
-                return next;
-              });
-            }}
-            sx={{ p: 0, width: 20, height: 20 }}
-          >
-            {collapsedHierarchyIds.has(node.id) ? (
-              <ChevronRightRounded fontSize="small" />
-            ) : (
-              <ExpandMoreRounded fontSize="small" />
-            )}
-          </IconButton>
-        ) : (
-          <Box sx={{ width: 20, height: 20 }} />
-        )}
-        <Box sx={{ display: "grid", placeItems: "center", color: "primary.main" }}>
-          <HierarchyIcon nodeKind={node.nodeKind} />
-        </Box>
-        <ListItemText
-          primary={node.name}
-          secondary={node.code}
-          sx={{ minWidth: 0, my: 0 }}
-          slotProps={{
-            primary: {
-              noWrap: true,
-              fontSize: "0.84rem",
-              fontWeight: 700,
-              color: "#17243B",
-            },
-            secondary: {
-              noWrap: true,
-              fontSize: "0.72rem",
-              color: "#667085",
-            },
-          }}
-        />
-      </ListItemButton>,
-      ...(collapsedHierarchyIds.has(node.id) ? [] : renderHierarchy(node.children, depth + 1)),
-    ]);
-  const buildingMap = maps.find((map) => map.buildingId === selectedBuildingId);
+  const showInspector = inspectorOpen || selectedRegion !== null;
 
-  const save = async (): Promise<void> => {
-    if (!canEdit || editor.draft === null) return;
-    setSaveMessage(null);
-    setConflict(false);
-    try {
-      const saved = await api.saveMap(editor.draft.id, {
-        expectedRevision: editor.draft.revision,
-        regions: toInputs(editor.draft),
-      });
-      dispatch({ type: "saved", map: saved });
-      setSaveMessage("Map saved");
-    } catch (error) {
-      if (error instanceof ApiError && error.status === 409) setConflict(true);
-      else setSaveMessage(error instanceof Error ? error.message : "Map could not be saved");
-    }
-  };
+  const hierarchyRoot = locations.data?.[0].root ?? null;
+  const hierarchyNodes = useMemo(
+    () => (hierarchyRoot === null ? [] : flattenHierarchy([hierarchyRoot])),
+    [hierarchyRoot],
+  );
+  const nodesById = useMemo(
+    () => new Map(hierarchyNodes.map((node) => [node.id, node])),
+    [hierarchyNodes],
+  );
+  const assignableNodes = useMemo(
+    () =>
+      hierarchyNodes.filter(
+        (node) => node.buildingId === draft?.buildingId && node.status === "Active",
+      ),
+    [hierarchyNodes, draft?.buildingId],
+  );
+  const parentRegionOptions = useMemo(
+    () =>
+      regions.filter((region) => region.id !== selectedRegion?.id && region.status === "Active"),
+    [regions, selectedRegion?.id],
+  );
+  const selectedBuilding = useMemo(
+    () => buildings.find((building) => building.id === selectedBuildingId),
+    [buildings, selectedBuildingId],
+  );
+  const buildingHasMap = useMemo(
+    () => maps.some((map) => map.buildingId === selectedBuildingId),
+    [maps, selectedBuildingId],
+  );
 
-  const uploadBackground = async (file: File): Promise<void> => {
-    if (!canEdit || editor.draft === null) return;
-    if (file.type !== "image/png" && file.type !== "image/jpeg") {
-      setSaveMessage("Choose a PNG or JPEG floor plan.");
-      return;
-    }
-    setSaveMessage(null);
-    setConflict(false);
-    try {
-      const saved = await api.uploadFloorPlan(editor.draft.id, {
-        expectedRevision: editor.draft.revision,
-        regions: toInputs(editor.draft),
-        originalFileName: file.name,
-        mediaType: file.type,
-        contentBase64: await fileAsBase64(file),
-      });
-      dispatch({ type: "saved", map: saved });
-      setSaveMessage("Floor plan uploaded and map saved");
-    } catch (error) {
-      if (error instanceof ApiError && error.status === 409) setConflict(true);
-      else
-        setSaveMessage(error instanceof Error ? error.message : "Floor plan could not be uploaded");
-    }
-  };
-
-  const createHierarchyNode = async (): Promise<void> => {
-    if (
-      !canEdit ||
-      defaultParentId === null ||
-      newNodeName.trim() === "" ||
-      newNodeCode.trim() === ""
-    ) {
-      setSaveMessage("Enter a code, name, and parent location.");
-      return;
-    }
-    try {
-      const created = await api.createHierarchyNode({
-        code: newNodeCode,
-        name: newNodeName,
-        nodeKind: newNodeKind,
-        operationalKind: newNodeKind === "Building" ? "Container" : "Storage",
-        parentId: defaultParentId,
-      });
-      setNewNodeCode("");
-      setNewNodeName("");
-      if (created.nodeKind === "Building") {
-        setBuildingId(created.id);
-        setSelectedHierarchyNodeId(created.id);
-        setHierarchyName(created.name);
-      }
-      setSaveMessage("Hierarchy node created");
-      refreshLocations();
-    } catch (error) {
-      setSaveMessage(error instanceof Error ? error.message : "Location could not be created");
-    }
-  };
-
-  const refreshLocations = (): void => {
+  const reloadAll = useCallback((): void => {
     locations.reload();
     mapResource.reload();
-  };
+  }, [locations, mapResource]);
 
-  const saveHierarchyName = async (): Promise<void> => {
-    if (!canEdit || selectedHierarchyNode === undefined) return;
-    try {
-      await api.renameLocation(selectedHierarchyNode.id, hierarchyName);
-      setSaveMessage("Location renamed");
-      refreshLocations();
-    } catch (error) {
-      setSaveMessage(error instanceof Error ? error.message : "Location could not be renamed");
-    }
-  };
-
-  const moveHierarchyNode = async (parentId: string): Promise<void> => {
-    if (!canEdit || selectedHierarchyNode === undefined || parentId === "none") return;
-    try {
-      await api.moveLocation(selectedHierarchyNode.id, parentId);
-      setSaveMessage("Location moved");
-      refreshLocations();
-    } catch (error) {
-      setSaveMessage(error instanceof Error ? error.message : "Location could not be moved");
-    }
-  };
-
-  const archiveHierarchyNode = async (): Promise<void> => {
-    if (!canEdit || selectedHierarchyNode === undefined) return;
-    if (!window.confirm(`Archive ${selectedHierarchyNode.name}?`)) return;
-    try {
-      await api.archiveLocation(selectedHierarchyNode.id);
-      setSelectedHierarchyNodeId(null);
-      setSaveMessage("Location archived");
-      refreshLocations();
-    } catch (error) {
-      setSaveMessage(error instanceof Error ? error.message : "Location could not be archived");
-    }
-  };
-
-  const deleteHierarchyNode = async (): Promise<void> => {
-    if (!canEdit || selectedHierarchyNode === undefined) return;
-    if (!window.confirm(`Delete ${selectedHierarchyNode.name}?`)) return;
-    try {
-      await api.deleteLocation(selectedHierarchyNode.id);
-      if (selectedHierarchyNode.nodeKind === "Building") setBuildingId(null);
-      setSelectedHierarchyNodeId(null);
-      setSaveMessage("Location deleted");
-      refreshLocations();
-    } catch (error) {
-      setSaveMessage(error instanceof Error ? error.message : "Location could not be deleted");
-    }
-  };
-
-  const startBuildingCreation = (): void => {
-    setNewNodeKind("Building");
-    setNewNodeParentId(branchId);
-    document.getElementById("new-location-code")?.focus();
-  };
-
-  const onCanvasPointerDown = (event: PointerEvent<SVGSVGElement>): void => {
-    if (!canEdit || editor.draft === null) return;
-    if (editor.mode === "polygon")
-      dispatch({ type: "points", points: [...editor.drawingPoints, pointFromEvent(event)] });
-    if (editor.mode === "rectangle")
-      dispatch({ type: "rectangle-start", point: pointFromEvent(event) });
-  };
-  const finishPolygon = (): void => {
-    if (editor.drawingPoints.length < 3) return;
-    dispatch({
-      type: "add",
-      region: {
-        id: `draft-${String(Date.now())}`,
-        displayName: "New region",
-        hierarchyNodeId: editor.draft?.buildingId ?? "",
-        parentRegionId: null,
-        geometry: { kind: "Polygon", points: editor.drawingPoints },
-        zOrder: (editor.draft?.regions.length ?? 0) + 1,
-        searchAliases: [],
-        status: "Active",
-        stock: {
-          status: "OutOfStock",
-          colour: "#D32F2F",
-          text: "Out of stock",
-          icon: "remove-circle",
-          itemCount: 0,
-          quantity: "0",
-        },
-      },
-    });
-  };
-  const drawRectangle = (event: PointerEvent<SVGSVGElement>): void => {
-    if (
-      !canEdit ||
-      editor.mode !== "rectangle" ||
-      editor.draft === null ||
-      editor.rectangleStart === null
-    )
+  const reportFailure = useCallback((error: unknown, fallback: string): void => {
+    if (error instanceof ApiError && error.status === 409) {
+      setConflict(true);
       return;
-    const point = pointFromEvent(event);
-    const start = editor.rectangleStart;
-    const x = Math.min(start.x, point.x);
-    const y = Math.min(start.y, point.y);
-    const right = Math.max(start.x, point.x);
-    const bottom = Math.max(start.y, point.y);
-    const boundedX = Math.min(x, 0.98);
-    const boundedY = Math.min(y, 0.98);
-    dispatch({
-      type: "add",
-      region: {
-        id: `draft-${String(Date.now())}`,
-        displayName: "New region",
-        hierarchyNodeId: editor.draft.buildingId,
-        parentRegionId: null,
-        geometry: {
-          kind: "Rectangle",
-          x: boundedX,
-          y: boundedY,
-          width: Math.max(0.02, Math.min(1, right) - boundedX),
-          height: Math.max(0.02, Math.min(1, bottom) - boundedY),
-        },
-        zOrder: editor.draft.regions.length + 1,
-        searchAliases: [],
-        status: "Active",
-        stock: {
-          status: "OutOfStock",
-          colour: "#D32F2F",
-          text: "Out of stock",
-          icon: "remove-circle",
-          itemCount: 0,
-          quantity: "0",
-        },
-      },
-    });
-  };
-  const onCanvasPointerMove = (event: PointerEvent<SVGSVGElement>): void => {
-    const current = interaction.current;
-    if (!canEdit || current === null || canvasRef.current === null) return;
-    const point = pointFromClient(event.clientX, event.clientY, canvasRef.current);
-    const region = editor.draft?.regions.find((candidate) => candidate.id === current.regionId);
-    if (region === undefined) return;
-    const geometry =
-      current.kind === "move"
-        ? moveGeometry(
-            current.geometry,
-            point.x - current.startPoint.x,
-            point.y - current.startPoint.y,
-          )
-        : resizeRectangle(current.geometry, current.handle, point);
-    dispatch({ type: "update", region: { ...region, geometry } });
-  };
-  const onCanvasPointerUp = (): void => {
-    interaction.current = null;
-    if (editor.mode === "rectangle") dispatch({ type: "rectangle-start", point: null });
-  };
-  const beginRegionMove = (event: PointerEvent<SVGElement>, region: MapRegionView): void => {
-    event.stopPropagation();
-    dispatch({ type: "select", id: region.id });
-    if (!canEdit || editor.mode !== "select" || canvasRef.current === null) return;
-    interaction.current = {
-      kind: "move",
-      regionId: region.id,
-      startPoint: pointFromClient(event.clientX, event.clientY, canvasRef.current),
-      geometry: region.geometry,
-    };
-  };
-  const beginResize = (
-    event: PointerEvent<SVGCircleElement>,
-    region: MapRegionView,
-    handle: "nw" | "ne" | "sw" | "se",
-  ): void => {
-    event.stopPropagation();
-    if (!canEdit || editor.mode !== "select" || region.geometry.kind !== "Rectangle") return;
-    dispatch({ type: "select", id: region.id });
-    interaction.current = {
-      kind: "resize",
-      regionId: region.id,
-      handle,
-      geometry: region.geometry,
-    };
-  };
-  const onRegionKeyDown = (event: React.KeyboardEvent<SVGElement>, region: MapRegionView): void => {
-    if (!canEdit) return;
-    const step = event.shiftKey ? 0.02 : 0.005;
-    const dx = event.key === "ArrowLeft" ? -step : event.key === "ArrowRight" ? step : 0;
-    const dy = event.key === "ArrowUp" ? -step : event.key === "ArrowDown" ? step : 0;
-    if (dx === 0 && dy === 0) return;
-    event.preventDefault();
-    dispatch({
-      type: "update",
-      region: { ...region, geometry: moveGeometry(region.geometry, dx, dy) },
-    });
-  };
+    }
+    setSaveMessage(error instanceof Error ? error.message : fallback);
+  }, []);
 
-  const legend = useMemo(
-    () =>
-      [
-        ["#2E7D32", "Available", <CheckCircleRounded fontSize="inherit" />],
-        ["#ED6C02", "Low stock", <WarningAmberRounded fontSize="inherit" />],
-        ["#D32F2F", "Out of stock", <RemoveCircleOutlineRounded fontSize="inherit" />],
-        ["#757575", "Archived", <ArchiveRounded fontSize="inherit" />],
-      ] as const,
-    [],
+  const save = useCallback((): void => {
+    if (!canEdit || draft === null || editor.persisted === null) return;
+    setSaveMessage(null);
+    setConflict(false);
+    api
+      .saveMap(draft.id, {
+        expectedRevision: editor.persisted.revision,
+        regions: toInputs(draft),
+      })
+      .then((saved) => {
+        dispatch({ type: "saved", map: saved });
+        setSaveMessage("Map saved");
+      })
+      .catch((error: unknown) => {
+        reportFailure(error, "Map could not be saved");
+      });
+  }, [api, canEdit, draft, editor.persisted, reportFailure]);
+
+  const uploadFloorPlan = useCallback(
+    (file: File): void => {
+      if (!canEdit || draft === null || editor.persisted === null) return;
+      if (file.type !== "image/png" && file.type !== "image/jpeg") {
+        setSaveMessage("Choose a PNG or JPEG floor plan.");
+        return;
+      }
+      setSaveMessage(null);
+      setConflict(false);
+      const reader = new FileReader();
+      reader.addEventListener("error", () => {
+        setSaveMessage("Floor plan could not be read.");
+      });
+      reader.addEventListener("load", () => {
+        const value = typeof reader.result === "string" ? reader.result : "";
+        api
+          .uploadFloorPlan(draft.id, {
+            expectedRevision: editor.persisted?.revision ?? draft.revision,
+            regions: toInputs(draft),
+            originalFileName: file.name,
+            mediaType: file.type as "image/png" | "image/jpeg",
+            contentBase64: value.split(",", 2)[1] ?? "",
+          })
+          .then((saved) => {
+            dispatch({ type: "saved", map: saved });
+            setSaveMessage("Floor plan uploaded and map saved");
+          })
+          .catch((error: unknown) => {
+            reportFailure(error, "Floor plan could not be uploaded");
+          });
+      });
+      reader.readAsDataURL(file);
+    },
+    [api, canEdit, draft, editor.persisted, reportFailure],
   );
 
-  const selectedBuilding = buildings.find((building) => building.id === selectedBuildingId);
+  const createMap = useCallback((): void => {
+    if (selectedBuildingId === null) return;
+    api
+      .createMap(selectedBuildingId)
+      .then((map) => {
+        dispatch({ type: "load", map });
+        locations.reload();
+      })
+      .catch((error: unknown) => {
+        reportFailure(error, "Map could not be created");
+      });
+  }, [api, locations, reportFailure, selectedBuildingId]);
+
+  const createNode = useCallback(
+    (request: CreateHierarchyNodeRequest): void => {
+      if (request.code.trim() === "" || request.name.trim() === "") {
+        setSaveMessage("Enter a code, name, and parent location.");
+        return;
+      }
+      api
+        .createHierarchyNode(request)
+        .then((created) => {
+          if (created.nodeKind === "Building") {
+            setBuildingId(created.id);
+            setSelectedNodeId(created.id);
+          }
+          setSaveMessage("Hierarchy node created");
+          reloadAll();
+        })
+        .catch((error: unknown) => {
+          reportFailure(error, "Location could not be created");
+        });
+    },
+    [api, reloadAll, reportFailure],
+  );
+
+  const renameNode = useCallback(
+    (id: string, name: string): void => {
+      api
+        .renameLocation(id, name)
+        .then(() => {
+          setSaveMessage("Location renamed");
+          reloadAll();
+        })
+        .catch((error: unknown) => {
+          reportFailure(error, "Location could not be renamed");
+        });
+    },
+    [api, reloadAll, reportFailure],
+  );
+
+  const moveNode = useCallback(
+    (id: string, parentId: string): void => {
+      api
+        .moveLocation(id, parentId)
+        .then(() => {
+          setSaveMessage("Location moved");
+          reloadAll();
+        })
+        .catch((error: unknown) => {
+          reportFailure(error, "Location could not be moved");
+        });
+    },
+    [api, reloadAll, reportFailure],
+  );
+
+  const archiveNode = useCallback(
+    (id: string): void => {
+      if (!window.confirm(`Archive ${nodesById.get(id)?.name ?? "this location"}?`)) return;
+      api
+        .archiveLocation(id)
+        .then(() => {
+          setSelectedNodeId(null);
+          setSaveMessage("Location archived");
+          reloadAll();
+        })
+        .catch((error: unknown) => {
+          reportFailure(error, "Location could not be archived");
+        });
+    },
+    [api, nodesById, reloadAll, reportFailure],
+  );
+
+  const deleteNode = useCallback(
+    (id: string): void => {
+      const node = nodesById.get(id);
+      if (!window.confirm(`Delete ${node?.name ?? "this location"}?`)) return;
+      api
+        .deleteLocation(id)
+        .then(() => {
+          if (node?.nodeKind === "Building") setBuildingId(null);
+          setSelectedNodeId(null);
+          setSaveMessage("Location deleted");
+          reloadAll();
+        })
+        .catch((error: unknown) => {
+          reportFailure(error, "Location could not be deleted");
+        });
+    },
+    [api, nodesById, reloadAll, reportFailure],
+  );
+
+  const selectNode = useCallback((node: HierarchyNodeView): void => {
+    setSelectedNodeId(node.id);
+    if (node.nodeKind === "Building") setBuildingId(node.id);
+  }, []);
+
+  const toggleNode = useCallback((id: string): void => {
+    setCollapsedIds((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const selectSearchResult = useCallback((result: LocationSearchResult): void => {
+    if (result.location.buildingId !== null) setBuildingId(result.location.buildingId);
+    /* Select now for the map already on screen; the effect above covers the rest. */
+    setPendingFocusRegionId(result.regionId);
+    dispatch({ type: "select", id: result.regionId });
+  }, []);
+
+  const selectRegion = useCallback((id: string | null): void => {
+    dispatch({ type: "select", id });
+  }, []);
+  const commitGeometry = useCallback((id: string, geometry: MapGeometry): void => {
+    dispatch({ type: "commit-geometry", id, geometry });
+  }, []);
+  const createRegion = useCallback((geometry: MapGeometry): void => {
+    dispatch({ type: "add-region", geometry });
+  }, []);
+  const removeRegion = useCallback((id: string): void => {
+    dispatch({ type: "remove-region", id });
+  }, []);
+  const patchRegion = useCallback((id: string, changes: RegionChanges): void => {
+    dispatch({ type: "patch-region", id, changes });
+  }, []);
+  const reorderRegion = useCallback((id: string, direction: "raise" | "lower"): void => {
+    dispatch({ type: "reorder-region", id, direction });
+  }, []);
+  const changeMode = useCallback((mode: EditorMode): void => {
+    dispatch({ type: "mode", mode });
+  }, []);
+  const toggleSnap = useCallback((): void => {
+    dispatch({ type: "toggle-snap" });
+  }, []);
+  const revert = useCallback((): void => {
+    dispatch({ type: "revert" });
+  }, []);
+  const closeInspector = useCallback((): void => {
+    dispatch({ type: "select", id: null });
+    setInspectorOpen(false);
+  }, []);
 
   return (
     <Box
@@ -818,7 +432,9 @@ export function LocationsPage(): ReactElement {
                 labelId="building-label"
                 label="Building"
                 value={selectedBuildingId ?? ""}
-                onChange={(event) => setBuildingId(event.target.value)}
+                onChange={(event) => {
+                  setBuildingId(event.target.value);
+                }}
               >
                 {buildings.map((building) => (
                   <MenuItem key={building.id} value={building.id}>
@@ -831,8 +447,8 @@ export function LocationsPage(): ReactElement {
               variant="outlined"
               size="small"
               startIcon={<AddRounded />}
-              onClick={startBuildingCreation}
-              disabled={!canEdit || branchId === null}
+              onClick={() => document.getElementById("new-location-code")?.focus()}
+              disabled={!canEdit || hierarchyRoot === null}
             >
               Add building
             </Button>
@@ -840,8 +456,8 @@ export function LocationsPage(): ReactElement {
               variant="outlined"
               size="small"
               startIcon={<MapRounded />}
-              onClick={() => canvasRef.current?.focus()}
-              disabled={editor.draft === null}
+              onClick={() => svgRef.current?.focus()}
+              disabled={draft === null}
             >
               Edit map
             </Button>
@@ -853,7 +469,7 @@ export function LocationsPage(): ReactElement {
               <Alert
                 severity="warning"
                 action={
-                  <Button color="inherit" onClick={() => mapResource.reload()}>
+                  <Button color="inherit" onClick={mapResource.reload}>
                     Reload latest
                   </Button>
                 }
@@ -864,8 +480,10 @@ export function LocationsPage(): ReactElement {
             )}
             {saveMessage !== null && (
               <Alert
-                severity={saveMessage === "Map saved" ? "success" : "error"}
-                onClose={() => setSaveMessage(null)}
+                severity={saveMessage.endsWith("saved") ? "success" : "error"}
+                onClose={() => {
+                  setSaveMessage(null);
+                }}
                 sx={{ py: 0.25 }}
               >
                 {saveMessage}
@@ -886,675 +504,53 @@ export function LocationsPage(): ReactElement {
           minHeight: 0,
           overflow: { xs: "visible", lg: "hidden" },
           border: "1px solid",
-          borderColor: "#D9E0E9",
+          borderColor: mapBorder,
           borderRadius: 1.5,
           bgcolor: "background.paper",
         }}
       >
-        <Box
-          component="aside"
-          aria-label="Location hierarchy and search"
-          sx={{
-            display: "grid",
-            gridTemplateRows: "auto minmax(0, 1fr)",
-            minWidth: 0,
-            minHeight: { xs: 420, lg: 0 },
-            overflow: "hidden",
-            borderRight: { lg: "1px solid #D9E0E9" },
-          }}
-        >
-          <Box sx={{ p: 1.5, borderBottom: "1px solid #E2E7EE" }}>
-            <Stack
-              direction="row"
-              justifyContent="space-between"
-              alignItems="center"
-              sx={{ mb: 1 }}
-            >
-              <Stack direction="row" spacing={0.75} alignItems="center">
-                <AccountTreeRounded fontSize="small" color="primary" />
-                <Typography sx={{ fontWeight: 800 }}>Locations</Typography>
-              </Stack>
-              {canEdit && (
-                <Tooltip title="Add location">
-                  <IconButton
-                    size="small"
-                    aria-label="Add location"
-                    onClick={() => document.getElementById("new-location-code")?.focus()}
-                  >
-                    <AddRounded fontSize="small" />
-                  </IconButton>
-                </Tooltip>
-              )}
-            </Stack>
-            <TextField
-              fullWidth
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search locations…"
-              size="small"
-              inputProps={{ "aria-label": "Search locations" }}
-              InputProps={{
-                startAdornment: (
-                  <SearchRounded fontSize="small" sx={{ mr: 1, color: "text.secondary" }} />
-                ),
-              }}
-            />
-          </Box>
-          <Box sx={{ minHeight: 0, overflowY: "auto", p: 1.25 }}>
-            {searchResource.data !== undefined && query.trim().length > 0 && (
-              <Box sx={{ mb: 2 }}>
-                <Typography variant="overline" color="text.secondary" sx={{ px: 1 }}>
-                  Search results
-                </Typography>
-                <List dense disablePadding aria-label="Search results">
-                  {searchResource.data.map((result) => (
-                    <ListItemButton
-                      key={`${result.mapId ?? "location"}-${result.location.id}`}
-                      selected={focusedId === result.regionId}
-                      onClick={() => {
-                        setFocusedId(result.regionId);
-                        if (
-                          result.mapId !== editor.draft?.id &&
-                          result.location.buildingId !== null
-                        )
-                          setBuildingId(result.location.buildingId);
-                      }}
-                      sx={{ minHeight: 44 }}
-                    >
-                      <ListItemText
-                        primary={result.location.name}
-                        secondary={`${result.location.code} · ${result.matchedOn}`}
-                      />
-                    </ListItemButton>
-                  ))}
-                </List>
-              </Box>
-            )}
-            <Stack
-              direction="row"
-              justifyContent="space-between"
-              alignItems="center"
-              sx={{ px: 1 }}
-            >
-              <Typography variant="overline" color="text.secondary">
-                Hierarchy
-              </Typography>
-              <Typography variant="caption" color="text.secondary">
-                {buildings.length} building{buildings.length === 1 ? "" : "s"}
-              </Typography>
-            </Stack>
-            {buildings.length === 0 ? (
-              <Typography color="text.secondary" sx={{ px: 1, py: 2 }}>
-                No buildings configured yet.
-              </Typography>
-            ) : (
-              <List dense disablePadding aria-label="Location hierarchy">
-                {locations.data === undefined ? [] : renderHierarchy([locations.data[0].root])}
-              </List>
-            )}
-            {canEdit && (
-              <Stack spacing={1} sx={{ mt: 2, pt: 2, px: 1, borderTop: "1px solid #E2E7EE" }}>
-                <Typography variant="overline" color="text.secondary">
-                  Add hierarchy node
-                </Typography>
-                <TextField
-                  id="new-location-code"
-                  size="small"
-                  label="Code"
-                  value={newNodeCode}
-                  onChange={(event) => setNewNodeCode(event.target.value)}
-                />
-                <TextField
-                  size="small"
-                  label="Name"
-                  value={newNodeName}
-                  onChange={(event) => setNewNodeName(event.target.value)}
-                />
-                <FormControl size="small">
-                  <InputLabel id="new-node-kind-label">Type</InputLabel>
-                  <Select
-                    labelId="new-node-kind-label"
-                    label="Type"
-                    value={newNodeKind}
-                    onChange={(event) => {
-                      const kind = event.target.value;
-                      setNewNodeKind(kind);
-                      if (kind === "Building") setNewNodeParentId(branchId);
-                      else if (newNodeParentId === branchId) setNewNodeParentId(null);
-                    }}
-                  >
-                    {["Building", "Area", "Aisle", "Shelf", "Bin", "CustomSection"].map((kind) => (
-                      <MenuItem key={kind} value={kind}>
-                        {kind}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-                <FormControl size="small">
-                  <InputLabel id="new-node-parent-label">Parent</InputLabel>
-                  <Select
-                    labelId="new-node-parent-label"
-                    label="Parent"
-                    value={defaultParentId ?? ""}
-                    onChange={(event) => setNewNodeParentId(event.target.value)}
-                  >
-                    {hierarchyOptions
-                      .filter((node) =>
-                        newNodeKind === "Building"
-                          ? node.nodeKind === "Branch"
-                          : node.nodeKind !== "Bin" && node.nodeKind !== "Branch",
-                      )
-                      .map((node) => (
-                        <MenuItem key={node.id} value={node.id}>
-                          {node.name} · {node.code}
-                        </MenuItem>
-                      ))}
-                  </Select>
-                </FormControl>
-                <Button
-                  variant="outlined"
-                  startIcon={<AddRounded />}
-                  onClick={() => void createHierarchyNode()}
-                >
-                  Add location
-                </Button>
-                {selectedHierarchyNode !== undefined &&
-                  selectedHierarchyNode.nodeKind !== "Branch" && (
-                    <Stack spacing={1} sx={{ pt: 1.5, borderTop: "1px solid #E2E7EE" }}>
-                      <Typography variant="overline" color="text.secondary">
-                        Edit selected location
-                      </Typography>
-                      <TextField
-                        size="small"
-                        label="Name"
-                        value={hierarchyName}
-                        onChange={(event) => setHierarchyName(event.target.value)}
-                      />
-                      <Stack direction="row" spacing={1}>
-                        <Button
-                          size="small"
-                          variant="outlined"
-                          onClick={() => void saveHierarchyName()}
-                        >
-                          Rename
-                        </Button>
-                        <Button
-                          size="small"
-                          color="error"
-                          startIcon={<ArchiveRounded />}
-                          onClick={() => void archiveHierarchyNode()}
-                        >
-                          Archive
-                        </Button>
-                        <Button
-                          size="small"
-                          color="error"
-                          variant="outlined"
-                          startIcon={<DeleteOutlineRounded />}
-                          onClick={() => void deleteHierarchyNode()}
-                          disabled={selectedHierarchyNode.status === "Archived"}
-                        >
-                          Delete
-                        </Button>
-                      </Stack>
-                      <FormControl size="small">
-                        <InputLabel id="move-location-parent-label">Move under</InputLabel>
-                        <Select
-                          labelId="move-location-parent-label"
-                          label="Move under"
-                          value={selectedHierarchyNode.parentId ?? "none"}
-                          onChange={(event) => void moveHierarchyNode(event.target.value)}
-                        >
-                          <MenuItem value="none">No parent</MenuItem>
-                          {hierarchyOptions
-                            .filter(
-                              (node) =>
-                                node.id !== selectedHierarchyNode.id && node.status === "Active",
-                            )
-                            .map((node) => (
-                              <MenuItem key={node.id} value={node.id}>
-                                {node.name} · {node.code}
-                              </MenuItem>
-                            ))}
-                        </Select>
-                      </FormControl>
-                    </Stack>
-                  )}
-              </Stack>
-            )}
-          </Box>
-        </Box>
-        <Box
-          component="section"
-          aria-label="Building map"
-          sx={{
-            display: "grid",
-            gridTemplateRows: "auto minmax(0, 1fr)",
-            minWidth: 0,
-            minHeight: { xs: 600, lg: 0 },
-            overflow: "hidden",
-          }}
-        >
-          <Box
-            component="nav"
-            aria-label="Map toolbar"
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              gap: 1,
-              minHeight: 48,
-              px: 1.25,
-              py: 0.75,
-              borderBottom: "1px solid #D9E0E9",
-              bgcolor: "#FFFFFF",
-              flexWrap: "wrap",
-            }}
-          >
-            <Stack direction="row" spacing={0.5} alignItems="center" flexWrap="wrap">
-              <Box
-                sx={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 0.25,
-                  pr: 1,
-                  mr: 0.5,
-                  borderRight: "1px solid #E2E7EE",
-                }}
-              >
-                {canEdit ? (
-                  <ToggleButtonGroup
-                    exclusive
-                    size="small"
-                    value={editor.mode === "select" || editor.mode === "pan" ? editor.mode : null}
-                    onChange={(_, value: EditorMode | null) => {
-                      if (value !== null) dispatch({ type: "mode", mode: value });
-                    }}
-                    aria-label="Navigation tools"
-                    sx={{ height: 34 }}
-                  >
-                    <ToggleButton value="select" aria-label="Select mode" title="Select">
-                      <EditRounded fontSize="small" />
-                    </ToggleButton>
-                    <ToggleButton value="pan" aria-label="Pan map" title="Pan">
-                      <PanToolRounded fontSize="small" />
-                    </ToggleButton>
-                  </ToggleButtonGroup>
-                ) : (
-                  <Chip size="small" label="View only" variant="outlined" />
-                )}
-              </Box>
-              {canEdit && (
-                <Box
-                  sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 0.25,
-                    pr: 1,
-                    mr: 0.5,
-                    borderRight: "1px solid #E2E7EE",
-                  }}
-                >
-                  <ToggleButtonGroup
-                    exclusive
-                    size="small"
-                    value={
-                      editor.mode === "rectangle" || editor.mode === "polygon" ? editor.mode : null
-                    }
-                    onChange={(_, value: EditorMode | null) => {
-                      if (value !== null) dispatch({ type: "mode", mode: value });
-                    }}
-                    aria-label="Drawing tools"
-                    sx={{ height: 34 }}
-                  >
-                    <ToggleButton value="rectangle" aria-label="Draw rectangle" title="Rectangle">
-                      <Box
-                        component="span"
-                        sx={{ width: 16, height: 12, border: "2px solid currentColor" }}
-                      />
-                    </ToggleButton>
-                    <ToggleButton value="polygon" aria-label="Draw polygon" title="Polygon">
-                      <PolylineRounded fontSize="small" />
-                    </ToggleButton>
-                  </ToggleButtonGroup>
-                </Box>
-              )}
-              <Stack direction="row" spacing={0.25} alignItems="center">
-                <ToolbarButton
-                  label="Zoom out"
-                  onClick={() => dispatch({ type: "zoom", amount: -0.25 })}
-                >
-                  <ZoomOutRounded fontSize="small" />
-                </ToolbarButton>
-                <Typography
-                  variant="caption"
-                  sx={{
-                    minWidth: 42,
-                    textAlign: "center",
-                    fontWeight: 800,
-                    color: "text.secondary",
-                  }}
-                >
-                  {String(Math.round(editor.zoom * 100))}%
-                </Typography>
-                <ToolbarButton
-                  label="Zoom in"
-                  onClick={() => dispatch({ type: "zoom", amount: 0.25 })}
-                >
-                  <ZoomInRounded fontSize="small" />
-                </ToolbarButton>
-                <ToolbarButton
-                  label="Fit map to canvas"
-                  onClick={() => dispatch({ type: "zoom", amount: 1 - editor.zoom })}
-                >
-                  <FitScreenRounded fontSize="small" />
-                </ToolbarButton>
-              </Stack>
-              <Chip
-                size="small"
-                icon={<GridOnRounded />}
-                label={`Editing map · ${modeLabel(canEdit ? editor.mode : "select")}`}
-                variant="outlined"
-                sx={{ display: { xs: "none", xl: "inline-flex" } }}
-              />
-            </Stack>
-            <Stack direction="row" spacing={0.75} alignItems="center">
-              {editor.dirty && <Chip size="small" label="Unsaved changes" color="warning" />}
-              {canEdit && (
-                <>
-                  <input
-                    ref={fileInput}
-                    hidden
-                    type="file"
-                    accept="image/png,image/jpeg"
-                    aria-label="Upload floor plan"
-                    onChange={(event) => {
-                      const file = event.target.files?.[0];
-                      event.target.value = "";
-                      if (file !== undefined) void uploadBackground(file);
-                    }}
-                  />
-                  {editor.draft !== null && (
-                    <>
-                      <Button
-                        size="small"
-                        startIcon={<UploadFileRounded />}
-                        onClick={() => fileInput.current?.click()}
-                        sx={{ minHeight: 34, px: 1.25, display: { xs: "none", sm: "inline-flex" } }}
-                      >
-                        Upload floor plan
-                      </Button>
-                      <Button
-                        size="small"
-                        variant="contained"
-                        onClick={() => void save()}
-                        sx={{ minHeight: 34, px: 1.5 }}
-                      >
-                        Save
-                      </Button>
-                      <Button
-                        size="small"
-                        onClick={() => dispatch({ type: "revert" })}
-                        disabled={!editor.dirty}
-                        sx={{ minHeight: 34, px: 1.25, display: { xs: "none", sm: "inline-flex" } }}
-                      >
-                        Revert
-                      </Button>
-                    </>
-                  )}
-                </>
-              )}
-            </Stack>
-          </Box>
-          <Box
-            sx={{
-              position: "relative",
-              minWidth: 0,
-              minHeight: 0,
-              overflow: "hidden",
-              bgcolor: "#F8FAFC",
-              backgroundImage:
-                "linear-gradient(#DFE5EE 1px, transparent 1px), linear-gradient(90deg, #DFE5EE 1px, transparent 1px)",
-              backgroundSize: "24px 24px",
-            }}
-          >
-            {mapResource.status === "error" &&
-            buildingMap === undefined &&
-            canEdit &&
-            selectedBuildingId !== null ? (
-              <Stack
-                alignItems="center"
-                justifyContent="center"
-                spacing={1.25}
-                sx={{ position: "absolute", inset: 0, p: 4, textAlign: "center" }}
-              >
-                <Box
-                  sx={{
-                    display: "grid",
-                    placeItems: "center",
-                    width: 52,
-                    height: 52,
-                    borderRadius: "50%",
-                    color: "primary.main",
-                    bgcolor: "#E8EEF9",
-                  }}
-                >
-                  <MapRounded />
-                </Box>
-                <Typography variant="h3" component="h2">
-                  No storage map yet
-                </Typography>
-                <Typography color="text.secondary" sx={{ maxWidth: 420 }}>
-                  Create a blank map and draw storage regions for this building.
-                </Typography>
-                <Button
-                  startIcon={<AddRounded />}
-                  variant="contained"
-                  onClick={() =>
-                    void api.createMap(selectedBuildingId).then((map) => {
-                      dispatch({ type: "load", map });
-                      locations.reload();
-                    })
-                  }
-                >
-                  Create blank map
-                </Button>
-              </Stack>
-            ) : editor.draft === null ? (
-              <Typography
-                color="text.secondary"
-                sx={{ position: "absolute", inset: 0, display: "grid", placeItems: "center" }}
-              >
-                Loading map…
-              </Typography>
-            ) : (
-              <Box
-                sx={{
-                  position: "absolute",
-                  inset: 0,
-                  overflow: "hidden",
-                }}
-              >
-                <svg
-                  ref={canvasRef}
-                  viewBox="0 0 100 100"
-                  role="application"
-                  aria-label={`${editor.draft.building.name} map`}
-                  tabIndex={0}
-                  onPointerDown={onCanvasPointerDown}
-                  onPointerMove={onCanvasPointerMove}
-                  onPointerUp={(event) => {
-                    drawRectangle(event);
-                    onCanvasPointerUp();
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" && editor.mode === "polygon") finishPolygon();
-                    if (event.key === "Escape") dispatch({ type: "points", points: [] });
-                  }}
-                  style={{
-                    width: "100%",
-                    height: "100%",
-                    transform: `scale(${String(editor.zoom)})`,
-                    transformOrigin: "center",
-                  }}
-                >
-                  {editor.draft.background.kind === "FloorPlan" &&
-                    editor.draft.background.downloadPath !== undefined && (
-                      <image
-                        href={editor.draft.background.downloadPath}
-                        x="0"
-                        y="0"
-                        width="100"
-                        height="100"
-                        preserveAspectRatio="xMidYMid slice"
-                        opacity="0.28"
-                        aria-label={editor.draft.background.originalFileName ?? "Floor plan"}
-                      />
-                    )}
-                  {editor.drawingPoints.length > 1 && (
-                    <polyline
-                      points={geometryString({ kind: "Polygon", points: editor.drawingPoints })}
-                      fill="none"
-                      stroke="#00309D"
-                      strokeWidth="0.8"
-                      strokeDasharray="2 1"
-                    />
-                  )}
-                  {editor.draft.regions.map((region) => {
-                    const selected =
-                      focusedId === region.id || editor.selectedRegionId === region.id;
-                    return (
-                      <g
-                        key={region.id}
-                        data-region-id={region.id}
-                        opacity={region.status === "Archived" ? 0.42 : 0.82}
-                      >
-                        {region.geometry.kind === "Rectangle" ? (
-                          <rect
-                            x={region.geometry.x * 100}
-                            y={region.geometry.y * 100}
-                            width={region.geometry.width * 100}
-                            height={region.geometry.height * 100}
-                            fill={region.stock.colour}
-                            stroke={selected ? "#071B3A" : "#FFFFFF"}
-                            strokeWidth={selected ? 1.4 : 0.6}
-                            onPointerDown={(event) => beginRegionMove(event, region)}
-                            onKeyDown={(event) => onRegionKeyDown(event, region)}
-                            tabIndex={0}
-                            role="button"
-                            aria-label={`${region.displayName}, ${region.stock.text}`}
-                          />
-                        ) : (
-                          <polygon
-                            points={geometryString(region.geometry)}
-                            fill={region.stock.colour}
-                            stroke={selected ? "#071B3A" : "#FFFFFF"}
-                            strokeWidth={selected ? 1.4 : 0.6}
-                            onPointerDown={(event) => beginRegionMove(event, region)}
-                            onKeyDown={(event) => onRegionKeyDown(event, region)}
-                            tabIndex={0}
-                            role="button"
-                            aria-label={`${region.displayName}, ${region.stock.text}`}
-                          />
-                        )}
-                        {canEdit && selected && region.geometry.kind === "Rectangle" && (
-                          <>
-                            {(
-                              [
-                                ["nw", region.geometry.x, region.geometry.y],
-                                [
-                                  "ne",
-                                  region.geometry.x + region.geometry.width,
-                                  region.geometry.y,
-                                ],
-                                [
-                                  "sw",
-                                  region.geometry.x,
-                                  region.geometry.y + region.geometry.height,
-                                ],
-                                [
-                                  "se",
-                                  region.geometry.x + region.geometry.width,
-                                  region.geometry.y + region.geometry.height,
-                                ],
-                              ] as const
-                            ).map(([handle, x, y]) => (
-                              <circle
-                                key={handle}
-                                cx={x * 100}
-                                cy={y * 100}
-                                r="1.4"
-                                fill="#fff"
-                                stroke="#071B3A"
-                                strokeWidth="0.5"
-                                tabIndex={0}
-                                role="button"
-                                aria-label={`Resize ${region.displayName} ${handle}`}
-                                onPointerDown={(event) => beginResize(event, region, handle)}
-                              />
-                            ))}
-                          </>
-                        )}
-                      </g>
-                    );
-                  })}
-                </svg>
-              </Box>
-            )}
-            {editor.mode === "polygon" && editor.drawingPoints.length > 0 && (
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                sx={{
-                  position: "absolute",
-                  left: 16,
-                  bottom: 16,
-                  px: 1.25,
-                  py: 0.75,
-                  border: "1px solid #D8DEE8",
-                  borderRadius: 1,
-                  bgcolor: "rgba(255,255,255,0.92)",
-                  boxShadow: "0 4px 14px rgba(19,36,65,0.08)",
-                }}
-              >
-                Click to add points. Press Enter to complete or Escape to cancel.
-              </Typography>
-            )}
-            {editor.draft !== null && (
-              <Stack
-                direction="row"
-                spacing={1.5}
-                flexWrap="wrap"
-                aria-label="Map status legend"
-                sx={{
-                  position: "absolute",
-                  right: 16,
-                  bottom: 16,
-                  maxWidth: "calc(100% - 32px)",
-                  px: 1.25,
-                  py: 0.75,
-                  border: "1px solid #D8DEE8",
-                  borderRadius: 1,
-                  bgcolor: "rgba(255,255,255,0.92)",
-                  boxShadow: "0 4px 14px rgba(19,36,65,0.08)",
-                  backdropFilter: "blur(6px)",
-                  fontSize: "0.75rem",
-                }}
-              >
-                {legend.map(([colour, label, icon]) => (
-                  <Stack key={label} direction="row" spacing={0.5} alignItems="center">
-                    <Box
-                      aria-hidden="true"
-                      sx={{ width: 8, height: 8, bgcolor: colour, borderRadius: "50%" }}
-                    />
-                    <Box sx={{ display: "grid", placeItems: "center", color: colour }}>{icon}</Box>
-                    <Typography variant="caption">{label}</Typography>
-                  </Stack>
-                ))}
-              </Stack>
-            )}
-          </Box>
-        </Box>
+        <HierarchyPanel
+          canEdit={canEdit}
+          root={hierarchyRoot}
+          buildings={buildings}
+          nodes={hierarchyNodes}
+          selectedNodeId={selectedNodeId}
+          selectedBuildingId={selectedBuildingId}
+          collapsedIds={collapsedIds}
+          query={query}
+          searchResults={searchResource.data}
+          focusedRegionId={editor.selectedRegionId}
+          onQueryChange={setQuery}
+          onSelectSearchResult={selectSearchResult}
+          onSelectNode={selectNode}
+          onToggleNode={toggleNode}
+          onCreateNode={createNode}
+          onRenameNode={renameNode}
+          onMoveNode={moveNode}
+          onArchiveNode={archiveNode}
+          onDeleteNode={deleteNode}
+        />
+        <MapWorkspace
+          map={draft}
+          canEdit={canEdit}
+          dirty={editor.dirty}
+          mode={editor.mode}
+          snapEnabled={editor.snapEnabled}
+          selectedRegionId={editor.selectedRegionId}
+          canCreateMap={canEdit && !buildingHasMap && selectedBuildingId !== null}
+          svgRef={svgRef}
+          onModeChange={changeMode}
+          onToggleSnap={toggleSnap}
+          onSelect={selectRegion}
+          onCommitGeometry={commitGeometry}
+          onCreateRegion={createRegion}
+          onRemoveRegion={removeRegion}
+          onSave={save}
+          onRevert={revert}
+          onUploadFile={uploadFloorPlan}
+          onCreateMap={createMap}
+          onProblem={setSaveMessage}
+        />
         {showInspector ? (
           <Box
             component="aside"
@@ -1563,246 +559,27 @@ export function LocationsPage(): ReactElement {
               minWidth: 0,
               minHeight: { xs: 360, lg: 0 },
               overflowY: "auto",
-              borderLeft: { lg: "1px solid #D9E0E9" },
+              borderLeft: { lg: `1px solid ${mapBorder}` },
             }}
           >
-            <Box sx={{ p: 1.75 }}>
-              <Stack direction="row" justifyContent="space-between" alignItems="start">
-                <Box>
-                  <Typography variant="overline" color="text.secondary">
-                    Region details
-                  </Typography>
-                  {selectedRegion !== null && (
-                    <>
-                      <Typography variant="h3" component="h2" sx={{ mt: 0.25 }}>
-                        {selectedRegion.displayName}
-                      </Typography>
-                      <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 700 }}>
-                        {hierarchyOptions.find((node) => node.id === selectedRegion.hierarchyNodeId)
-                          ?.code ?? selectedRegion.hierarchyNodeId}
-                      </Typography>
-                    </>
-                  )}
-                </Box>
-                <IconButton
-                  size="small"
-                  aria-label="Close region details"
-                  onClick={() => {
-                    dispatch({ type: "select", id: null });
-                    setInspectorOpen(false);
-                  }}
-                >
-                  <CloseRounded fontSize="small" />
-                </IconButton>
-              </Stack>
-              {selectedRegion === null ? (
-                <Stack spacing={1.25} sx={{ pt: 7, pb: 5 }}>
-                  <MapRounded color="primary" sx={{ fontSize: 36 }} />
-                  <Typography sx={{ fontWeight: 800 }}>Nothing selected</Typography>
-                  <Typography variant="body2" color="text.secondary">
-                    Select a region on the map to view its assigned location, stock status, item
-                    quantities and dimensions.
-                  </Typography>
-                </Stack>
-              ) : (
-                <Stack spacing={1.75} sx={{ mt: 1.5 }}>
-                  <Box sx={{ pb: 1.75, borderBottom: "1px solid #E2E7EE" }}>
-                    <Typography variant="overline" color="text.secondary">
-                      Stock status
-                    </Typography>
-                    <Chip
-                      icon={<StockStatusIcon status={selectedRegion.stock.status} />}
-                      label={selectedRegion.stock.text}
-                      sx={{
-                        mt: 0.75,
-                        alignSelf: "start",
-                        bgcolor: selectedRegion.stock.colour,
-                        color: "#fff",
-                        "& .MuiChip-icon": { color: "inherit" },
-                      }}
-                    />
-                    <Stack direction="row" spacing={2.5} sx={{ mt: 1.5 }}>
-                      <Box>
-                        <Typography variant="h4">{selectedRegion.stock.itemCount}</Typography>
-                        <Typography variant="caption" color="text.secondary">
-                          item types
-                        </Typography>
-                      </Box>
-                      <Box>
-                        <Typography variant="h4">{selectedRegion.stock.quantity}</Typography>
-                        <Typography variant="caption" color="text.secondary">
-                          total units
-                        </Typography>
-                      </Box>
-                    </Stack>
-                  </Box>
-                  <Box sx={{ pb: 1.75, borderBottom: "1px solid #E2E7EE" }}>
-                    <Typography variant="overline" color="text.secondary">
-                      Mapped area
-                    </Typography>
-                    <Typography variant="body2" sx={{ mt: 0.5, fontWeight: 700 }}>
-                      {geometrySummary(selectedRegion.geometry)}
-                    </Typography>
-                    <Typography variant="caption" color="text.secondary">
-                      Use the selected region handles or arrow keys to adjust its position.
-                    </Typography>
-                  </Box>
-                  {canEdit && (
-                    <Stack spacing={1.25}>
-                      <Typography variant="overline" color="text.secondary">
-                        Properties
-                      </Typography>
-                      <TextField
-                        fullWidth
-                        label="Region name"
-                        size="small"
-                        value={selectedRegion.displayName}
-                        onChange={(event) =>
-                          dispatch({
-                            type: "update",
-                            region: { ...selectedRegion, displayName: event.target.value },
-                          })
-                        }
-                      />
-                      <FormControl fullWidth size="small">
-                        <InputLabel id="region-location-label">Location assignment</InputLabel>
-                        <Select
-                          labelId="region-location-label"
-                          label="Location assignment"
-                          value={selectedRegion.hierarchyNodeId}
-                          onChange={(event) =>
-                            dispatch({
-                              type: "update",
-                              region: { ...selectedRegion, hierarchyNodeId: event.target.value },
-                            })
-                          }
-                        >
-                          {hierarchyOptions
-                            .filter(
-                              (node) =>
-                                node.buildingId === editor.draft?.buildingId &&
-                                node.status === "Active",
-                            )
-                            .map((node) => (
-                              <MenuItem key={node.id} value={node.id}>
-                                {node.name} · {node.code}
-                              </MenuItem>
-                            ))}
-                        </Select>
-                      </FormControl>
-                      <FormControl fullWidth size="small">
-                        <InputLabel id="region-parent-label">Visual parent</InputLabel>
-                        <Select
-                          labelId="region-parent-label"
-                          label="Visual parent"
-                          value={selectedRegion.parentRegionId ?? "none"}
-                          onChange={(event) =>
-                            dispatch({
-                              type: "update",
-                              region: {
-                                ...selectedRegion,
-                                parentRegionId:
-                                  event.target.value === "none" ? null : event.target.value,
-                              },
-                            })
-                          }
-                        >
-                          <MenuItem value="none">None</MenuItem>
-                          {editor.draft?.regions
-                            .filter(
-                              (region) =>
-                                region.id !== selectedRegion.id && region.status === "Active",
-                            )
-                            .map((region) => (
-                              <MenuItem key={region.id} value={region.id}>
-                                {region.displayName}
-                              </MenuItem>
-                            ))}
-                        </Select>
-                      </FormControl>
-                      <TextField
-                        fullWidth
-                        label="Search aliases"
-                        size="small"
-                        value={selectedRegion.searchAliases.join(", ")}
-                        helperText="Separate aliases with commas"
-                        onChange={(event) =>
-                          dispatch({
-                            type: "update",
-                            region: {
-                              ...selectedRegion,
-                              searchAliases: event.target.value
-                                .split(",")
-                                .map((alias) => alias.trim())
-                                .filter((alias) => alias.length > 0),
-                            },
-                          })
-                        }
-                      />
-                      <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
-                        <Button
-                          size="small"
-                          startIcon={<ArrowUpwardRounded />}
-                          onClick={() =>
-                            dispatch({
-                              type: "update",
-                              region: { ...selectedRegion, zOrder: selectedRegion.zOrder + 1 },
-                            })
-                          }
-                          sx={{ minHeight: 36, px: 1.25 }}
-                        >
-                          Raise
-                        </Button>
-                        <Button
-                          size="small"
-                          startIcon={<ArrowDownwardRounded />}
-                          onClick={() =>
-                            dispatch({
-                              type: "update",
-                              region: { ...selectedRegion, zOrder: selectedRegion.zOrder - 1 },
-                            })
-                          }
-                          sx={{ minHeight: 36, px: 1.25 }}
-                        >
-                          Lower
-                        </Button>
-                        <Button
-                          size="small"
-                          color="error"
-                          startIcon={<ArchiveRounded />}
-                          onClick={() => {
-                            if (window.confirm("Archive this map region?"))
-                              dispatch({
-                                type: "update",
-                                region: {
-                                  ...selectedRegion,
-                                  status:
-                                    selectedRegion.status === "Archived" ? "Active" : "Archived",
-                                },
-                              });
-                          }}
-                          sx={{ minHeight: 36, px: 1.25 }}
-                        >
-                          {selectedRegion.status === "Archived" ? "Restore" : "Archive"}
-                        </Button>
-                      </Stack>
-                      <Button
-                        fullWidth
-                        variant="contained"
-                        onClick={() => void save()}
-                        disabled={!editor.dirty}
-                        sx={{ mt: 0.5 }}
-                      >
-                        Save changes
-                      </Button>
-                      <Typography variant="caption" color="text.secondary">
-                        Arrow keys move the selected region. Shift + Arrow moves farther.
-                      </Typography>
-                    </Stack>
-                  )}
-                </Stack>
-              )}
-            </Box>
+            <RegionInspector
+              region={selectedRegion}
+              canEdit={canEdit}
+              dirty={editor.dirty}
+              locationCode={
+                selectedRegion === null
+                  ? ""
+                  : (nodesById.get(selectedRegion.hierarchyNodeId)?.code ??
+                    selectedRegion.hierarchyNodeId)
+              }
+              nodeOptions={assignableNodes}
+              parentOptions={parentRegionOptions}
+              onPatch={patchRegion}
+              onReorder={reorderRegion}
+              onRemove={removeRegion}
+              onClose={closeInspector}
+              onSave={save}
+            />
           </Box>
         ) : (
           <Box
@@ -1814,7 +591,7 @@ export function LocationsPage(): ReactElement {
               alignItems: "center",
               gap: 1,
               p: 0.75,
-              borderLeft: "1px solid #D9E0E9",
+              borderLeft: `1px solid ${mapBorder}`,
               bgcolor: "#FBFCFE",
             }}
           >
@@ -1822,7 +599,9 @@ export function LocationsPage(): ReactElement {
               <IconButton
                 size="small"
                 aria-label="Open region details"
-                onClick={() => setInspectorOpen(true)}
+                onClick={() => {
+                  setInspectorOpen(true);
+                }}
               >
                 <MapRounded fontSize="small" />
               </IconButton>

--- a/apps/web/src/pages/SignInPage.test.ts
+++ b/apps/web/src/pages/SignInPage.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_SIGNED_IN_PATH, getRedirectPath, signInPathFor } from "./SignInPage";
+
+const ITEM = "/inventory/21290659-a871-46d5-94e0-c979de2afd4c";
+
+describe("signInPathFor", () => {
+  it("remembers a deep link in the query string", () => {
+    expect(signInPathFor(ITEM)).toBe(`/sign-in?next=${encodeURIComponent(ITEM)}`);
+  });
+
+  it("stays plain for anything that is not a deep link", () => {
+    expect(signInPathFor("/inventory")).toBe("/sign-in");
+    expect(signInPathFor("//evil.example.com")).toBe("/sign-in");
+  });
+});
+
+describe("getRedirectPath", () => {
+  it("returns to a scanned item recorded in the query string", () => {
+    /*
+     * The case the demo journey exercises: arriving from a QR code is a full
+     * page load, which discards router history state, so the query string is
+     * the only carrier that survives.
+     */
+    expect(getRedirectPath(null, `?next=${encodeURIComponent(ITEM)}`)).toBe(ITEM);
+  });
+
+  it("round-trips whatever signInPathFor produced", () => {
+    const search = signInPathFor(ITEM).slice("/sign-in".length);
+    expect(getRedirectPath(undefined, search)).toBe(ITEM);
+  });
+
+  it("still honours router state, for in-app navigations", () => {
+    expect(getRedirectPath({ from: ITEM })).toBe(ITEM);
+  });
+
+  it("prefers the query string when the two disagree", () => {
+    expect(getRedirectPath({ from: "/jobs/abc" }, `?next=${encodeURIComponent(ITEM)}`)).toBe(ITEM);
+  });
+
+  it("falls back to the dashboard when nothing usable is offered", () => {
+    expect(getRedirectPath(null)).toBe(DEFAULT_SIGNED_IN_PATH);
+    expect(getRedirectPath({})).toBe(DEFAULT_SIGNED_IN_PATH);
+    expect(getRedirectPath({ from: "/inventory" })).toBe(DEFAULT_SIGNED_IN_PATH);
+  });
+
+  it("refuses to be pointed off-site or back at itself", () => {
+    for (const hostile of [
+      "//evil.example.com/inventory/1",
+      "https://evil.example.com/inventory/1",
+      "/\\evil.example.com",
+      "/sign-in",
+    ])
+      expect(getRedirectPath(null, `?next=${encodeURIComponent(hostile)}`)).toBe(
+        DEFAULT_SIGNED_IN_PATH,
+      );
+  });
+});

--- a/apps/web/src/pages/SignInPage.tsx
+++ b/apps/web/src/pages/SignInPage.tsx
@@ -188,11 +188,21 @@ export function SignInPage(): ReactElement {
               <Box>
                 <Typography
                   component="p"
-                  sx={{ color: "primary.main", fontSize: "0.875rem", fontWeight: 700, letterSpacing: "0.04em" }}
+                  sx={{
+                    color: "primary.main",
+                    fontSize: "0.875rem",
+                    fontWeight: 700,
+                    letterSpacing: "0.04em",
+                  }}
                 >
                   StockControl
                 </Typography>
-                <Typography id="sign-in-title" component="h1" variant="h2" sx={{ lineHeight: 1.05 }}>
+                <Typography
+                  id="sign-in-title"
+                  component="h1"
+                  variant="h2"
+                  sx={{ lineHeight: 1.05 }}
+                >
                   Sign in
                 </Typography>
               </Box>
@@ -206,7 +216,11 @@ export function SignInPage(): ReactElement {
                   </Alert>
                 )}
                 <Stack spacing={0.75}>
-                  <Typography component="label" htmlFor="email" sx={{ color: "#263247", fontSize: "0.875rem", fontWeight: 600 }}>
+                  <Typography
+                    component="label"
+                    htmlFor="email"
+                    sx={{ color: "#263247", fontSize: "0.875rem", fontWeight: 600 }}
+                  >
                     Work email
                   </Typography>
                   <TextField
@@ -224,7 +238,11 @@ export function SignInPage(): ReactElement {
                   />
                 </Stack>
                 <Stack spacing={0.75}>
-                  <Typography component="label" htmlFor="password" sx={{ color: "#263247", fontSize: "0.875rem", fontWeight: 600 }}>
+                  <Typography
+                    component="label"
+                    htmlFor="password"
+                    sx={{ color: "#263247", fontSize: "0.875rem", fontWeight: 600 }}
+                  >
                     Password
                   </Typography>
                   <TextField

--- a/apps/web/src/pages/SignInPage.tsx
+++ b/apps/web/src/pages/SignInPage.tsx
@@ -37,35 +37,56 @@ const DEEP_LINK_PATTERNS: readonly RegExp[] = [
 
 export const DEFAULT_SIGNED_IN_PATH = "/dashboard";
 
-export function getRedirectPath(state: unknown): string {
-  if (typeof state !== "object" || state === null) {
-    return DEFAULT_SIGNED_IN_PATH;
-  }
+/** The query parameter carrying the page a signed-out visitor was trying to reach. */
+export const REDIRECT_QUERY_KEY = "next";
 
-  const redirectState = state as RedirectState;
-  const redirectPath = redirectState.from;
-
+/** Returns the candidate if it is a safe in-app deep link, otherwise null. */
+function safeDeepLink(candidate: unknown): string | null {
   if (
-    typeof redirectPath !== "string" ||
-    !redirectPath.startsWith("/") ||
-    redirectPath.startsWith("//") ||
-    redirectPath.includes("\\") ||
-    redirectPath === "/sign-in"
+    typeof candidate !== "string" ||
+    !candidate.startsWith("/") ||
+    candidate.startsWith("//") ||
+    candidate.includes("\\") ||
+    candidate === "/sign-in"
   ) {
-    return DEFAULT_SIGNED_IN_PATH;
+    return null;
   }
 
-  const resolvedUrl = new URL(redirectPath, window.location.origin);
+  const resolvedUrl = new URL(candidate, window.location.origin);
 
   if (resolvedUrl.origin !== window.location.origin) {
-    return DEFAULT_SIGNED_IN_PATH;
+    return null;
   }
 
   if (!DEEP_LINK_PATTERNS.some((pattern) => pattern.test(resolvedUrl.pathname))) {
-    return DEFAULT_SIGNED_IN_PATH;
+    return null;
   }
 
   return `${resolvedUrl.pathname}${resolvedUrl.search}${resolvedUrl.hash}`;
+}
+
+/**
+ * Where to land after signing in.
+ *
+ * The destination is read from the query string first and from router history
+ * state second. History state does not survive a full page load, which is
+ * exactly how someone arrives here from a scanned QR code, so the query string
+ * is what makes the deep link dependable; the state branch stays for in-app
+ * navigations that predate it.
+ */
+export function getRedirectPath(state: unknown, search = ""): string {
+  const fromQuery = new URLSearchParams(search).get(REDIRECT_QUERY_KEY);
+  const fromState =
+    typeof state === "object" && state !== null ? (state as RedirectState).from : undefined;
+
+  return safeDeepLink(fromQuery) ?? safeDeepLink(fromState) ?? DEFAULT_SIGNED_IN_PATH;
+}
+
+/** Builds the sign-in URL that remembers where the visitor was headed. */
+export function signInPathFor(attemptedPath: string): string {
+  return safeDeepLink(attemptedPath) === null
+    ? "/sign-in"
+    : `/sign-in?${REDIRECT_QUERY_KEY}=${encodeURIComponent(attemptedPath)}`;
 }
 
 export function SignInPage(): ReactElement {
@@ -98,7 +119,7 @@ export function SignInPage(): ReactElement {
 
     void signIn(normalizedEmail, password)
       .then(() => {
-        void navigate(getRedirectPath(location.state), { replace: true });
+        void navigate(getRedirectPath(location.state, location.search), { replace: true });
       })
       .catch(() => {
         setErrorMessage("We could not sign you in. Check your details and try again.");

--- a/apps/web/src/pages/locations/DrawPreviewLayer.tsx
+++ b/apps/web/src/pages/locations/DrawPreviewLayer.tsx
@@ -1,0 +1,83 @@
+import { memo, useSyncExternalStore, type ReactElement } from "react";
+
+import { MAP_UNITS, polylinePoints } from "./geometry";
+import type { LiveGeometryStore } from "./live-geometry-store";
+
+interface DrawPreviewLayerProps {
+  readonly scale: number;
+  readonly store: LiveGeometryStore;
+}
+
+const BRAND = "#00309D";
+
+/**
+ * The shape being drawn right now. The old editor showed nothing until the
+ * pointer came up, so drawing felt like it had not registered.
+ */
+export const DrawPreviewLayer = memo(function DrawPreviewLayer({
+  scale,
+  store,
+}: DrawPreviewLayerProps): ReactElement | null {
+  const preview = useSyncExternalStore(store.subscribe, store.getPreview);
+  if (preview === null) return null;
+
+  if (preview.kind === "rectangle") {
+    const { geometry } = preview;
+    return (
+      <rect
+        aria-hidden="true"
+        data-testid="draw-preview"
+        x={geometry.x * MAP_UNITS}
+        y={geometry.y * MAP_UNITS}
+        width={geometry.width * MAP_UNITS}
+        height={geometry.height * MAP_UNITS}
+        fill={BRAND}
+        fillOpacity={0.14}
+        stroke={BRAND}
+        strokeWidth={1.5}
+        strokeDasharray="6 3"
+        vectorEffect="non-scaling-stroke"
+      />
+    );
+  }
+
+  const first = preview.points[0];
+  const outline = preview.cursor === null ? preview.points : [...preview.points, preview.cursor];
+
+  return (
+    <g aria-hidden="true" data-testid="draw-preview">
+      <polyline
+        points={polylinePoints(outline)}
+        fill="none"
+        stroke={BRAND}
+        strokeWidth={1.5}
+        strokeDasharray="6 3"
+        vectorEffect="non-scaling-stroke"
+      />
+      {preview.points.map((point, index) => (
+        <circle
+          key={`${String(point.x)}-${String(point.y)}-${String(index)}`}
+          cx={point.x * MAP_UNITS}
+          cy={point.y * MAP_UNITS}
+          r={(index === 0 && preview.closeable ? 7 : 4) / scale}
+          fill={index === 0 && preview.closeable ? BRAND : "#FFFFFF"}
+          stroke={BRAND}
+          strokeWidth={1.5}
+          vectorEffect="non-scaling-stroke"
+        />
+      ))}
+      {/* Closing the ring by clicking the first point again, no keyboard needed. */}
+      {preview.closeable && first !== undefined && preview.cursor !== null && (
+        <line
+          x1={preview.cursor.x * MAP_UNITS}
+          y1={preview.cursor.y * MAP_UNITS}
+          x2={first.x * MAP_UNITS}
+          y2={first.y * MAP_UNITS}
+          stroke={BRAND}
+          strokeWidth={1.5}
+          vectorEffect="non-scaling-stroke"
+        />
+      )}
+    </g>
+  );
+});

--- a/apps/web/src/pages/locations/HierarchyPanel.tsx
+++ b/apps/web/src/pages/locations/HierarchyPanel.tsx
@@ -1,0 +1,367 @@
+import AccountTreeRounded from "@mui/icons-material/AccountTreeRounded";
+import AddRounded from "@mui/icons-material/AddRounded";
+import ArchiveRounded from "@mui/icons-material/ArchiveRounded";
+import DeleteOutlineRounded from "@mui/icons-material/DeleteOutlineRounded";
+import SearchRounded from "@mui/icons-material/SearchRounded";
+import {
+  Box,
+  Button,
+  FormControl,
+  IconButton,
+  InputLabel,
+  List,
+  ListItemButton,
+  ListItemText,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import type {
+  CreateHierarchyNodeRequest,
+  HierarchyNodeView,
+  LocationSearchResult,
+} from "@stockcontrol/contracts";
+import { memo, useEffect, useMemo, useState, type ReactElement } from "react";
+
+import { panelBorder } from "./constants";
+import { HierarchyTree } from "./HierarchyTree";
+
+type CreatableKind = "Building" | "Area" | "Aisle" | "Shelf" | "Bin" | "CustomSection";
+
+const creatableKinds: readonly CreatableKind[] = [
+  "Building",
+  "Area",
+  "Aisle",
+  "Shelf",
+  "Bin",
+  "CustomSection",
+];
+
+interface HierarchyPanelProps {
+  readonly canEdit: boolean;
+  readonly root: HierarchyNodeView | null;
+  readonly buildings: readonly HierarchyNodeView[];
+  readonly nodes: readonly HierarchyNodeView[];
+  readonly selectedNodeId: string | null;
+  readonly selectedBuildingId: string | null;
+  readonly collapsedIds: ReadonlySet<string>;
+  readonly query: string;
+  readonly searchResults: readonly LocationSearchResult[] | undefined;
+  readonly focusedRegionId: string | null;
+  readonly onQueryChange: (value: string) => void;
+  readonly onSelectSearchResult: (result: LocationSearchResult) => void;
+  readonly onSelectNode: (node: HierarchyNodeView) => void;
+  readonly onToggleNode: (id: string) => void;
+  readonly onCreateNode: (request: CreateHierarchyNodeRequest) => void;
+  readonly onRenameNode: (id: string, name: string) => void;
+  readonly onMoveNode: (id: string, parentId: string) => void;
+  readonly onArchiveNode: (id: string) => void;
+  readonly onDeleteNode: (id: string) => void;
+}
+
+const searchResultSx = { minHeight: 44 } as const;
+
+/**
+ * The left sidebar. The creation and rename form keeps its own state, so typing
+ * a location name never reaches the map canvas.
+ */
+export const HierarchyPanel = memo(function HierarchyPanel({
+  canEdit,
+  root,
+  buildings,
+  nodes,
+  selectedNodeId,
+  selectedBuildingId,
+  collapsedIds,
+  query,
+  searchResults,
+  focusedRegionId,
+  onQueryChange,
+  onSelectSearchResult,
+  onSelectNode,
+  onToggleNode,
+  onCreateNode,
+  onRenameNode,
+  onMoveNode,
+  onArchiveNode,
+  onDeleteNode,
+}: HierarchyPanelProps): ReactElement {
+  const [newNodeCode, setNewNodeCode] = useState("");
+  const [newNodeName, setNewNodeName] = useState("");
+  const [newNodeKind, setNewNodeKind] = useState<CreatableKind>("Area");
+  const [newNodeParentId, setNewNodeParentId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+
+  const selectedNode = useMemo(
+    () => nodes.find((node) => node.id === selectedNodeId),
+    [nodes, selectedNodeId],
+  );
+  const branchId = root?.id ?? null;
+  const parentId = newNodeParentId ?? (newNodeKind === "Building" ? branchId : selectedBuildingId);
+
+  useEffect(() => {
+    setRenameValue(selectedNode?.name ?? "");
+  }, [selectedNode]);
+
+  const parentOptions = useMemo(
+    () =>
+      nodes.filter((node) =>
+        newNodeKind === "Building"
+          ? node.nodeKind === "Branch"
+          : node.nodeKind !== "Bin" && node.nodeKind !== "Branch",
+      ),
+    [nodes, newNodeKind],
+  );
+  const moveOptions = useMemo(
+    () => nodes.filter((node) => node.id !== selectedNodeId && node.status === "Active"),
+    [nodes, selectedNodeId],
+  );
+
+  return (
+    <Box
+      component="aside"
+      aria-label="Location hierarchy and search"
+      sx={{
+        display: "grid",
+        gridTemplateRows: "auto minmax(0, 1fr)",
+        minWidth: 0,
+        minHeight: { xs: 420, lg: 0 },
+        overflow: "hidden",
+        borderRight: { lg: `1px solid ${panelBorder}` },
+      }}
+    >
+      <Box sx={{ p: 1.5, borderBottom: `1px solid ${panelBorder}` }}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1 }}>
+          <Stack direction="row" spacing={0.75} alignItems="center">
+            <AccountTreeRounded fontSize="small" color="primary" />
+            <Typography sx={{ fontWeight: 800 }}>Locations</Typography>
+          </Stack>
+          {canEdit && (
+            <Tooltip title="Add location">
+              <IconButton
+                size="small"
+                aria-label="Add location"
+                onClick={() => document.getElementById("new-location-code")?.focus()}
+              >
+                <AddRounded fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          )}
+        </Stack>
+        <TextField
+          fullWidth
+          value={query}
+          onChange={(event) => {
+            onQueryChange(event.target.value);
+          }}
+          placeholder="Search locations…"
+          size="small"
+          slotProps={{
+            htmlInput: { "aria-label": "Search locations" },
+            input: {
+              startAdornment: (
+                <SearchRounded fontSize="small" sx={{ mr: 1, color: "text.secondary" }} />
+              ),
+            },
+          }}
+        />
+      </Box>
+      <Box sx={{ minHeight: 0, overflowY: "auto", p: 1.25 }}>
+        {searchResults !== undefined && query.trim().length > 0 && (
+          <Box sx={{ mb: 2 }}>
+            <Typography variant="overline" color="text.secondary" sx={{ px: 1 }}>
+              Search results
+            </Typography>
+            <List dense disablePadding aria-label="Search results">
+              {searchResults.map((result) => (
+                <ListItemButton
+                  key={`${result.mapId ?? "location"}-${result.location.id}`}
+                  selected={focusedRegionId === result.regionId}
+                  onClick={() => {
+                    onSelectSearchResult(result);
+                  }}
+                  sx={searchResultSx}
+                >
+                  <ListItemText
+                    primary={result.location.name}
+                    secondary={`${result.location.code} · ${result.matchedOn}`}
+                  />
+                </ListItemButton>
+              ))}
+            </List>
+          </Box>
+        )}
+        <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ px: 1 }}>
+          <Typography variant="overline" color="text.secondary">
+            Hierarchy
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {buildings.length} building{buildings.length === 1 ? "" : "s"}
+          </Typography>
+        </Stack>
+        {root === null || buildings.length === 0 ? (
+          <Typography color="text.secondary" sx={{ px: 1, py: 2 }}>
+            No buildings configured yet.
+          </Typography>
+        ) : (
+          <HierarchyTree
+            root={root}
+            selectedId={selectedNodeId}
+            collapsedIds={collapsedIds}
+            onSelect={onSelectNode}
+            onToggle={onToggleNode}
+          />
+        )}
+        {canEdit && (
+          <Stack spacing={1} sx={{ mt: 2, pt: 2, px: 1, borderTop: `1px solid ${panelBorder}` }}>
+            <Typography variant="overline" color="text.secondary">
+              Add hierarchy node
+            </Typography>
+            <TextField
+              id="new-location-code"
+              size="small"
+              label="Code"
+              value={newNodeCode}
+              onChange={(event) => {
+                setNewNodeCode(event.target.value);
+              }}
+            />
+            <TextField
+              size="small"
+              label="Name"
+              value={newNodeName}
+              onChange={(event) => {
+                setNewNodeName(event.target.value);
+              }}
+            />
+            <FormControl size="small">
+              <InputLabel id="new-node-kind-label">Type</InputLabel>
+              <Select
+                labelId="new-node-kind-label"
+                label="Type"
+                value={newNodeKind}
+                onChange={(event) => {
+                  const kind = event.target.value;
+                  setNewNodeKind(kind);
+                  if (kind === "Building") setNewNodeParentId(branchId);
+                  else if (newNodeParentId === branchId) setNewNodeParentId(null);
+                }}
+              >
+                {creatableKinds.map((kind) => (
+                  <MenuItem key={kind} value={kind}>
+                    {kind}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl size="small">
+              <InputLabel id="new-node-parent-label">Parent</InputLabel>
+              <Select
+                labelId="new-node-parent-label"
+                label="Parent"
+                value={parentId ?? ""}
+                onChange={(event) => {
+                  setNewNodeParentId(event.target.value);
+                }}
+              >
+                {parentOptions.map((node) => (
+                  <MenuItem key={node.id} value={node.id}>
+                    {node.name} · {node.code}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <Button
+              variant="outlined"
+              startIcon={<AddRounded />}
+              onClick={() => {
+                if (parentId === null) return;
+                onCreateNode({
+                  code: newNodeCode,
+                  name: newNodeName,
+                  nodeKind: newNodeKind,
+                  operationalKind: newNodeKind === "Building" ? "Container" : "Storage",
+                  parentId,
+                });
+                setNewNodeCode("");
+                setNewNodeName("");
+              }}
+            >
+              Add location
+            </Button>
+            {selectedNode !== undefined && selectedNode.nodeKind !== "Branch" && (
+              <Stack spacing={1} sx={{ pt: 1.5, borderTop: `1px solid ${panelBorder}` }}>
+                <Typography variant="overline" color="text.secondary">
+                  Edit selected location
+                </Typography>
+                <TextField
+                  size="small"
+                  label="Name"
+                  value={renameValue}
+                  onChange={(event) => {
+                    setRenameValue(event.target.value);
+                  }}
+                />
+                <Stack direction="row" spacing={1}>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={() => {
+                      onRenameNode(selectedNode.id, renameValue);
+                    }}
+                  >
+                    Rename
+                  </Button>
+                  <Button
+                    size="small"
+                    color="error"
+                    startIcon={<ArchiveRounded />}
+                    onClick={() => {
+                      onArchiveNode(selectedNode.id);
+                    }}
+                  >
+                    Archive
+                  </Button>
+                  <Button
+                    size="small"
+                    color="error"
+                    variant="outlined"
+                    startIcon={<DeleteOutlineRounded />}
+                    onClick={() => {
+                      onDeleteNode(selectedNode.id);
+                    }}
+                    disabled={selectedNode.status === "Archived"}
+                  >
+                    Delete
+                  </Button>
+                </Stack>
+                <FormControl size="small">
+                  <InputLabel id="move-location-parent-label">Move under</InputLabel>
+                  <Select
+                    labelId="move-location-parent-label"
+                    label="Move under"
+                    value={selectedNode.parentId ?? "none"}
+                    onChange={(event) => {
+                      if (event.target.value !== "none")
+                        onMoveNode(selectedNode.id, event.target.value);
+                    }}
+                  >
+                    <MenuItem value="none">No parent</MenuItem>
+                    {moveOptions.map((node) => (
+                      <MenuItem key={node.id} value={node.id}>
+                        {node.name} · {node.code}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Stack>
+            )}
+          </Stack>
+        )}
+      </Box>
+    </Box>
+  );
+});

--- a/apps/web/src/pages/locations/HierarchyTree.tsx
+++ b/apps/web/src/pages/locations/HierarchyTree.tsx
@@ -1,0 +1,179 @@
+import AccountTreeRounded from "@mui/icons-material/AccountTreeRounded";
+import BusinessRounded from "@mui/icons-material/BusinessRounded";
+import ChevronRightRounded from "@mui/icons-material/ChevronRightRounded";
+import ExpandMoreRounded from "@mui/icons-material/ExpandMoreRounded";
+import FolderRounded from "@mui/icons-material/FolderRounded";
+import { Box, IconButton, List, ListItemButton, ListItemText, styled } from "@mui/material";
+import { memo, useCallback, useMemo, type CSSProperties, type ReactElement } from "react";
+import type { HierarchyNodeView } from "@stockcontrol/contracts";
+
+import { treeItemSlotProps } from "./constants";
+
+/**
+ * Compiled once, at module load. The old tree built a fresh `sx` object with
+ * nested `:hover` and `.Mui-selected` rules for every node on every render, so
+ * Emotion re-serialised the whole tree during a canvas drag. Depth arrives as a
+ * custom property, which means every row shares one class.
+ */
+const TreeRow = styled(ListItemButton)({
+  position: "relative",
+  display: "grid",
+  gridTemplateColumns: "24px minmax(0, 1fr)",
+  alignItems: "center",
+  gap: 4,
+  minHeight: 48,
+  paddingLeft: 4,
+  paddingRight: 8,
+  borderRadius: 8,
+  "&:hover": { backgroundColor: "#F3F6FB" },
+  "&.Mui-selected": {
+    backgroundColor: "#E8EEF9",
+    boxShadow: "inset 3px 0 0 #00309D",
+    "&:hover": { backgroundColor: "#E8EEF9" },
+  },
+});
+
+/*
+ * The expander sits beside the row rather than inside it. Nesting a button in a
+ * button is a real accessibility failure (axe `nested-interactive`), and the
+ * previous tree also put bare buttons directly inside a `<ul>`.
+ */
+const TreeItem = styled("li")({
+  display: "grid",
+  gridTemplateColumns: "20px minmax(0, 1fr)",
+  alignItems: "center",
+  gap: 4,
+  listStyle: "none",
+  paddingLeft: "calc(4px + var(--tree-depth, 0) * 16px)",
+});
+
+const toggleSx = { p: 0, width: 20, height: 20 } as const;
+const iconSx = { display: "grid", placeItems: "center", color: "primary.main" } as const;
+const spacerSx = { width: 20, height: 20 } as const;
+const textSx = { minWidth: 0, my: 0 } as const;
+
+function HierarchyIcon({
+  nodeKind,
+}: {
+  readonly nodeKind: HierarchyNodeView["nodeKind"];
+}): ReactElement {
+  if (nodeKind === "Branch") return <AccountTreeRounded fontSize="small" />;
+  if (nodeKind === "Building") return <BusinessRounded fontSize="small" />;
+  return <FolderRounded fontSize="small" />;
+}
+
+interface HierarchyTreeItemProps {
+  readonly node: HierarchyNodeView;
+  readonly depth: number;
+  readonly selected: boolean;
+  readonly collapsed: boolean;
+  readonly onSelect: (node: HierarchyNodeView) => void;
+  readonly onToggle: (id: string) => void;
+}
+
+const HierarchyTreeItem = memo(function HierarchyTreeItem({
+  node,
+  depth,
+  selected,
+  collapsed,
+  onSelect,
+  onToggle,
+}: HierarchyTreeItemProps): ReactElement {
+  const hasChildren = node.children.length > 0;
+
+  return (
+    <TreeItem style={{ "--tree-depth": depth } as CSSProperties}>
+      {hasChildren ? (
+        <IconButton
+          size="small"
+          aria-label={`${collapsed ? "Expand" : "Collapse"} ${node.name}`}
+          aria-expanded={!collapsed}
+          onClick={() => {
+            onToggle(node.id);
+          }}
+          sx={toggleSx}
+        >
+          {collapsed ? (
+            <ChevronRightRounded fontSize="small" />
+          ) : (
+            <ExpandMoreRounded fontSize="small" />
+          )}
+        </IconButton>
+      ) : (
+        <Box sx={spacerSx} />
+      )}
+      <TreeRow
+        selected={selected}
+        aria-current={selected ? "true" : undefined}
+        onClick={() => {
+          onSelect(node);
+        }}
+      >
+        <Box sx={iconSx}>
+          <HierarchyIcon nodeKind={node.nodeKind} />
+        </Box>
+        <ListItemText
+          primary={node.name}
+          secondary={node.code}
+          sx={textSx}
+          slotProps={treeItemSlotProps}
+        />
+      </TreeRow>
+    </TreeItem>
+  );
+});
+
+interface HierarchyTreeProps {
+  readonly root: HierarchyNodeView;
+  readonly selectedId: string | null;
+  readonly collapsedIds: ReadonlySet<string>;
+  readonly onSelect: (node: HierarchyNodeView) => void;
+  readonly onToggle: (id: string) => void;
+}
+
+interface VisibleRow {
+  readonly node: HierarchyNodeView;
+  readonly depth: number;
+}
+
+const visibleRows = (
+  nodes: readonly HierarchyNodeView[],
+  collapsedIds: ReadonlySet<string>,
+  depth = 0,
+): readonly VisibleRow[] =>
+  nodes.flatMap((node) => [
+    { node, depth },
+    ...(collapsedIds.has(node.id) ? [] : visibleRows(node.children, collapsedIds, depth + 1)),
+  ]);
+
+export const HierarchyTree = memo(function HierarchyTree({
+  root,
+  selectedId,
+  collapsedIds,
+  onSelect,
+  onToggle,
+}: HierarchyTreeProps): ReactElement {
+  const rows = useMemo(() => visibleRows([root], collapsedIds), [root, collapsedIds]);
+  const select = useCallback(
+    (node: HierarchyNodeView) => {
+      onSelect(node);
+    },
+    [onSelect],
+  );
+
+  return (
+    <List dense disablePadding aria-label="Location hierarchy">
+      {rows.map((row) => (
+        <HierarchyTreeItem
+          key={row.node.id}
+          node={row.node}
+          depth={row.depth}
+          selected={selectedId === row.node.id}
+          collapsed={collapsedIds.has(row.node.id)}
+          onSelect={select}
+          onToggle={onToggle}
+        />
+      ))}
+    </List>
+  );
+});

--- a/apps/web/src/pages/locations/MapCanvas.test.tsx
+++ b/apps/web/src/pages/locations/MapCanvas.test.tsx
@@ -1,0 +1,344 @@
+import type { AuthenticatedSession, MapRegionInput, SaveMapRequest } from "@stockcontrol/contracts";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { StockControlProviders } from "../../app/App";
+import type { AuthClient, SignInCredentials } from "../../auth/auth-types";
+import {
+  createFakeApiClient,
+  testMapId,
+  testPolygonRegionId,
+  testRectangleRegionId,
+  type RecordedRequest,
+} from "../../test/fake-api";
+import { mockCanvasLayout, runFramesSynchronously } from "../../test/layout";
+import { LocationsPage } from "../LocationsPage";
+
+/*
+ * The canvas is 800x600 with an 8px fit padding, so the map occupies a 584px
+ * square starting at (108, 8). Everything below is expressed against that.
+ */
+const CANVAS = { width: 800, height: 600 };
+const MAP_SIDE = 584;
+const MAP_LEFT = (CANVAS.width - MAP_SIDE) / 2;
+const MAP_TOP = (CANVAS.height - MAP_SIDE) / 2;
+
+/** Client coordinates for a normalized point on the map. */
+const at = (x: number, y: number): { clientX: number; clientY: number } => ({
+  clientX: MAP_LEFT + x * MAP_SIDE,
+  clientY: MAP_TOP + y * MAP_SIDE,
+});
+
+const session: AuthenticatedSession = {
+  user: {
+    id: "user-admin",
+    email: "admin@example.com",
+    displayName: "Sam Field",
+    role: "Admin",
+  },
+  issuedAt: "2026-07-30T09:00:00.000Z",
+  expiresAt: "2026-07-30T21:00:00.000Z",
+};
+
+class StubAuthClient implements AuthClient {
+  public getSession(signal: AbortSignal): Promise<AuthenticatedSession | null> {
+    signal.throwIfAborted();
+    return Promise.resolve(session);
+  }
+
+  public signIn(credentials: SignInCredentials): Promise<AuthenticatedSession> {
+    void credentials;
+    return Promise.resolve(session);
+  }
+
+  public signOut(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+interface Harness {
+  readonly requests: readonly RecordedRequest[];
+  readonly canvas: SVGSVGElement;
+}
+
+async function renderMap(): Promise<Harness> {
+  const requests: RecordedRequest[] = [];
+  const api = createFakeApiClient({}, (request) => {
+    requests.push(request);
+  });
+
+  render(
+    <StockControlProviders authClient={new StubAuthClient()} apiClient={api}>
+      <MemoryRouter initialEntries={["/locations"]}>
+        <Routes>
+          <Route path="/locations" element={<LocationsPage />} />
+        </Routes>
+      </MemoryRouter>
+    </StockControlProviders>,
+  );
+
+  const canvas = await screen.findByRole("application", { name: /Main warehouse map/u });
+  return { requests, canvas: canvas as unknown as SVGSVGElement };
+}
+
+const saved = (requests: readonly RecordedRequest[]): readonly MapRegionInput[] => {
+  const put = requests.filter(
+    (request) => request.method === "PUT" && request.path === `/maps/${testMapId}`,
+  );
+  return (put.at(-1)?.body as SaveMapRequest | undefined)?.regions ?? [];
+};
+
+const shapeFor = (id: string): SVGGraphicsElement => {
+  const element = document.querySelector(`[data-region-id="${id}"]`);
+  if (element === null) throw new Error(`No shape rendered for ${id}`);
+  return element as SVGGraphicsElement;
+};
+
+const worldTransform = (): string =>
+  document.querySelector("svg > g")?.getAttribute("transform") ?? "";
+
+const scaleFromTransform = (transform: string): number =>
+  Number(/scale\(([-\d.]+)\)/u.exec(transform)?.[1] ?? "0");
+
+const drag = (
+  canvas: SVGSVGElement,
+  from: { clientX: number; clientY: number },
+  through: readonly { clientX: number; clientY: number }[],
+  options: Record<string, unknown> = {},
+  /* Where the press lands. A real browser targets the shape; only moves bubble. */
+  target: Element = canvas,
+): void => {
+  fireEvent.pointerDown(target, { pointerId: 1, button: 0, buttons: 1, ...from, ...options });
+  for (const point of through)
+    fireEvent.pointerMove(canvas, { pointerId: 1, buttons: 1, ...point, ...options });
+  const last = through.at(-1) ?? from;
+  fireEvent.pointerUp(canvas, { pointerId: 1, button: 0, buttons: 0, ...last, ...options });
+};
+
+beforeEach(() => {
+  mockCanvasLayout(CANVAS);
+  runFramesSynchronously();
+});
+
+describe("pointer coordinates", () => {
+  /*
+   * The regression test for the original bug: the canvas is not square, and the
+   * old editor measured pointer positions across the element box while the SVG
+   * letterboxed its coordinate system, so shapes landed away from the cursor.
+   */
+  it("draws a rectangle where the pointer went on a non-square canvas", async () => {
+    const { requests, canvas } = await renderMap();
+
+    await userEvent.click(screen.getByRole("button", { name: "Draw rectangle" }));
+    drag(canvas, at(0.2, 0.2), [at(0.4, 0.3), at(0.5, 0.4)], { altKey: true });
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(saved(requests)).toHaveLength(3);
+    });
+    const drawn = saved(requests)[2]?.geometry;
+    expect(drawn?.kind).toBe("Rectangle");
+    if (drawn?.kind !== "Rectangle") throw new Error("expected a rectangle");
+    expect(drawn.x).toBeCloseTo(0.2, 2);
+    expect(drawn.y).toBeCloseTo(0.2, 2);
+    expect(drawn.width).toBeCloseTo(0.3, 2);
+    expect(drawn.height).toBeCloseTo(0.2, 2);
+  });
+
+  it("snaps to the grid unless Alt is held", async () => {
+    const { requests, canvas } = await renderMap();
+
+    await userEvent.click(screen.getByRole("button", { name: "Draw rectangle" }));
+    drag(canvas, at(0.213, 0.207), [at(0.487, 0.464)]);
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(saved(requests)).toHaveLength(3);
+    });
+    const drawn = saved(requests)[2]?.geometry;
+    if (drawn?.kind !== "Rectangle") throw new Error("expected a rectangle");
+    expect(drawn.x * 100).toBeCloseTo(Math.round(drawn.x * 100), 6);
+    expect(drawn.y * 100).toBeCloseTo(Math.round(drawn.y * 100), 6);
+  });
+});
+
+describe("dragging a region", () => {
+  it("moves the shape live and commits once when the pointer is released", async () => {
+    const { requests, canvas } = await renderMap();
+
+    const before = shapeFor(testRectangleRegionId).getAttribute("x");
+    drag(
+      canvas,
+      at(0.2, 0.15),
+      [at(0.3, 0.25), at(0.4, 0.35)],
+      { altKey: true },
+      shapeFor(testRectangleRegionId),
+    );
+    const after = shapeFor(testRectangleRegionId).getAttribute("x");
+
+    expect(Number(after)).toBeGreaterThan(Number(before));
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => {
+      expect(saved(requests)).toHaveLength(2);
+    });
+    const moved = saved(requests).find((region) => region.id === testRectangleRegionId)?.geometry;
+    if (moved?.kind !== "Rectangle") throw new Error("expected a rectangle");
+    expect(moved.x).toBeCloseTo(0.3, 2);
+    expect(moved.y).toBeCloseTo(0.3, 2);
+  });
+
+  it("stops following the pointer after the gesture is cancelled", async () => {
+    /*
+     * The old editor kept its drag record in a ref that nothing cleared when the
+     * pointer went away, so the region resumed moving on the next stray event.
+     */
+    const { canvas } = await renderMap();
+
+    fireEvent.pointerDown(shapeFor(testRectangleRegionId), {
+      pointerId: 1,
+      button: 0,
+      buttons: 1,
+      ...at(0.2, 0.15),
+    });
+    fireEvent.pointerMove(canvas, { pointerId: 1, buttons: 1, ...at(0.3, 0.25) });
+    fireEvent.pointerCancel(canvas, { pointerId: 1 });
+    const settled = shapeFor(testRectangleRegionId).getAttribute("x");
+    fireEvent.pointerMove(canvas, { pointerId: 1, buttons: 0, ...at(0.8, 0.8) });
+
+    expect(shapeFor(testRectangleRegionId).getAttribute("x")).toBe(settled);
+  });
+});
+
+describe("viewport", () => {
+  it("zooms towards the cursor and leaves the point under it in place", async () => {
+    const { canvas } = await renderMap();
+    const container = canvas.parentElement;
+    if (container === null) throw new Error("canvas has no container");
+
+    const before = worldTransform();
+    fireEvent.wheel(container, { deltaY: -200, ctrlKey: true, clientX: 300, clientY: 200 });
+    const after = worldTransform();
+
+    expect(scaleFromTransform(after)).toBeGreaterThan(scaleFromTransform(before));
+    /* The map point under (300, 200) must not have moved. */
+    const mapPointBefore = (300 - readTranslate(before)[0]) / scaleFromTransform(before);
+    const mapPointAfter = (300 - readTranslate(after)[0]) / scaleFromTransform(after);
+    expect(mapPointAfter).toBeCloseTo(mapPointBefore, 6);
+  });
+
+  it("pans on a plain wheel without changing the zoom", async () => {
+    const { canvas } = await renderMap();
+    const container = canvas.parentElement;
+    if (container === null) throw new Error("canvas has no container");
+
+    const before = worldTransform();
+    fireEvent.wheel(container, { deltaY: 120, clientX: 300, clientY: 200 });
+    const after = worldTransform();
+
+    expect(scaleFromTransform(after)).toBeCloseTo(scaleFromTransform(before), 9);
+    expect(readTranslate(after)[1]).toBeLessThan(readTranslate(before)[1]);
+  });
+
+  it("pans with the Pan tool, which previously did nothing at all", async () => {
+    const { canvas } = await renderMap();
+
+    await userEvent.click(screen.getByRole("button", { name: "Pan map" }));
+    const before = worldTransform();
+    drag(canvas, { clientX: 400, clientY: 300 }, [{ clientX: 460, clientY: 340 }]);
+    const after = worldTransform();
+
+    expect(readTranslate(after)[0]).toBeCloseTo(readTranslate(before)[0] + 60, 6);
+    expect(readTranslate(after)[1]).toBeCloseTo(readTranslate(before)[1] + 40, 6);
+    expect(scaleFromTransform(after)).toBeCloseTo(scaleFromTransform(before), 9);
+  });
+});
+
+function readTranslate(transform: string): readonly [number, number] {
+  const match = /translate\(([-\d.]+) ([-\d.]+)\)/u.exec(transform);
+  return [Number(match?.[1] ?? "0"), Number(match?.[2] ?? "0")];
+}
+
+describe("region ordering and removal", () => {
+  it("paints regions in z-order so Raise and Lower are visible", async () => {
+    await renderMap();
+
+    const order = (): readonly (string | null)[] =>
+      [...document.querySelectorAll("[data-region-id]")].map((node) =>
+        node.getAttribute("data-region-id"),
+      );
+    expect(order()).toEqual([testRectangleRegionId, testPolygonRegionId]);
+
+    await userEvent.click(screen.getByRole("button", { name: /Aisle A bays/u }));
+    await userEvent.click(await screen.findByRole("button", { name: "Raise" }));
+
+    expect(order()).toEqual([testPolygonRegionId, testRectangleRegionId]);
+  });
+
+  it("removes the selected region with the Delete key", async () => {
+    const { requests, canvas } = await renderMap();
+
+    await userEvent.click(screen.getByRole("button", { name: /Aisle A bays/u }));
+    fireEvent.keyDown(canvas, { key: "Delete" });
+
+    expect(document.querySelector(`[data-region-id="${testRectangleRegionId}"]`)).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => {
+      expect(saved(requests)).toHaveLength(1);
+    });
+    expect(saved(requests)[0]?.id).toBe(testPolygonRegionId);
+  });
+});
+
+describe("polygon drawing", () => {
+  it("previews while drawing and commits on Enter", async () => {
+    const { requests, canvas } = await renderMap();
+
+    await userEvent.click(screen.getByRole("button", { name: "Draw polygon" }));
+    for (const point of [at(0.2, 0.7), at(0.4, 0.7), at(0.3, 0.9)])
+      fireEvent.pointerDown(canvas, { pointerId: 1, button: 0, ...point });
+
+    expect(screen.getByTestId("draw-preview")).toBeInTheDocument();
+
+    fireEvent.keyDown(canvas, { key: "Enter" });
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(saved(requests)).toHaveLength(3);
+    });
+    expect(saved(requests)[2]?.geometry.kind).toBe("Polygon");
+  });
+
+  it("abandons the outline on Escape", async () => {
+    const { canvas } = await renderMap();
+
+    await userEvent.click(screen.getByRole("button", { name: "Draw polygon" }));
+    fireEvent.pointerDown(canvas, { pointerId: 1, button: 0, ...at(0.2, 0.7) });
+    expect(screen.getByTestId("draw-preview")).toBeInTheDocument();
+
+    fireEvent.keyDown(canvas, { key: "Escape" });
+    expect(screen.queryByTestId("draw-preview")).not.toBeInTheDocument();
+  });
+});
+
+describe("search", () => {
+  it("waits for typing to settle before asking the server", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const { requests } = await renderMap();
+      const field = screen.getByRole("textbox", { name: "Search locations" });
+
+      await userEvent.type(field, "aisle");
+      await vi.advanceTimersByTimeAsync(400);
+
+      await waitFor(() => {
+        expect(requests.filter((request) => request.path === "/locations/search")).toHaveLength(1);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/web/src/pages/locations/MapCanvas.tsx
+++ b/apps/web/src/pages/locations/MapCanvas.tsx
@@ -1,0 +1,158 @@
+import type { MapGeometry, MapSnapshot } from "@stockcontrol/contracts";
+import { Box } from "@mui/material";
+import { memo, useMemo, type ReactElement, type RefObject } from "react";
+
+import { canvasSurfaceSx, gridLine, mapBorder } from "./constants";
+import { DrawPreviewLayer } from "./DrawPreviewLayer";
+import { MAP_UNITS } from "./geometry";
+import type { EditorMode } from "./editor-state";
+import { sortedByZOrder } from "./editor-state";
+import type { LiveGeometryStore } from "./live-geometry-store";
+import { MapRegionShape } from "./MapRegionShape";
+import { SelectionHandles } from "./SelectionHandles";
+import { useCanvasInteraction } from "./use-canvas-interaction";
+import type { MapViewportController } from "./use-map-viewport";
+import { transformAttribute } from "./viewport";
+
+interface MapCanvasProps {
+  readonly map: MapSnapshot;
+  readonly canEdit: boolean;
+  readonly mode: EditorMode;
+  readonly snapEnabled: boolean;
+  readonly selectedRegionId: string | null;
+  readonly store: LiveGeometryStore;
+  readonly viewport: MapViewportController;
+  readonly svgRef: RefObject<SVGSVGElement | null>;
+  readonly onSelect: (id: string | null) => void;
+  readonly onCommitGeometry: (id: string, geometry: MapGeometry) => void;
+  readonly onCreateRegion: (geometry: MapGeometry) => void;
+  readonly onRemoveRegion: (id: string) => void;
+  readonly onProblem: (message: string) => void;
+}
+
+const GRID_ID = "map-editor-grid";
+/** Grid spacing in map units — one square is the snap step. */
+const GRID_STEP = 1;
+
+export const MapCanvas = memo(function MapCanvas({
+  map,
+  canEdit,
+  mode,
+  snapEnabled,
+  selectedRegionId,
+  store,
+  viewport,
+  svgRef,
+  onSelect,
+  onCommitGeometry,
+  onCreateRegion,
+  onRemoveRegion,
+  onProblem,
+}: MapCanvasProps): ReactElement {
+  const regions = useMemo(() => sortedByZOrder(map.regions), [map.regions]);
+  const selectedRegion = useMemo(
+    () => regions.find((region) => region.id === selectedRegionId) ?? null,
+    [regions, selectedRegionId],
+  );
+
+  const interaction = useCanvasInteraction({
+    canEdit,
+    mode,
+    snapEnabled,
+    regions,
+    selectedRegionId,
+    store,
+    viewport,
+    onSelect,
+    onCommitGeometry,
+    onCreateRegion,
+    onRemoveRegion,
+    onProblem,
+  });
+
+  const { scale } = viewport.viewport;
+
+  return (
+    <Box ref={viewport.attachContainer} sx={canvasSurfaceSx}>
+      <svg
+        ref={svgRef}
+        role="application"
+        aria-label={`${map.building.name} map`}
+        aria-activedescendant={
+          selectedRegionId === null ? undefined : `map-region-${selectedRegionId}`
+        }
+        tabIndex={0}
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "block",
+          touchAction: "none",
+          outlineOffset: -2,
+          cursor: interaction.cursor,
+        }}
+        onPointerDown={interaction.onPointerDown}
+        onPointerMove={interaction.onPointerMove}
+        onPointerUp={interaction.onPointerUp}
+        onPointerCancel={interaction.onPointerCancel}
+        onLostPointerCapture={interaction.onLostPointerCapture}
+        onKeyDown={interaction.onKeyDown}
+        onKeyUp={interaction.onKeyUp}
+      >
+        <defs>
+          {/*
+           * The grid lives inside the transformed group so it pans and zooms
+           * with the map. As a CSS background on the container it stayed put
+           * while the content moved, which read as the map sliding on glass.
+           */}
+          <pattern id={GRID_ID} width={GRID_STEP} height={GRID_STEP} patternUnits="userSpaceOnUse">
+            <path
+              d={`M ${String(GRID_STEP)} 0 L 0 0 0 ${String(GRID_STEP)}`}
+              fill="none"
+              stroke={gridLine}
+              strokeWidth={0.5}
+              vectorEffect="non-scaling-stroke"
+            />
+          </pattern>
+        </defs>
+        <g transform={transformAttribute(viewport.viewport)}>
+          <rect
+            x={0}
+            y={0}
+            width={MAP_UNITS}
+            height={MAP_UNITS}
+            fill="#FFFFFF"
+            stroke={mapBorder}
+            strokeWidth={1}
+            vectorEffect="non-scaling-stroke"
+          />
+          <rect x={0} y={0} width={MAP_UNITS} height={MAP_UNITS} fill={`url(#${GRID_ID})`} />
+          {map.background.kind === "FloorPlan" && map.background.downloadPath !== undefined && (
+            <image
+              href={map.background.downloadPath}
+              x={0}
+              y={0}
+              width={MAP_UNITS}
+              height={MAP_UNITS}
+              preserveAspectRatio="xMidYMid slice"
+              opacity={0.28}
+              aria-label={map.background.originalFileName ?? "Floor plan"}
+            />
+          )}
+          {regions.map((region) => (
+            <MapRegionShape
+              key={region.id}
+              region={region}
+              selected={region.id === selectedRegionId}
+              editable={canEdit}
+              store={store}
+            />
+          ))}
+          {canEdit && selectedRegion !== null && selectedRegion.status === "Active" && (
+            <SelectionHandles region={selectedRegion} scale={scale} store={store} />
+          )}
+          <DrawPreviewLayer scale={scale} store={store} />
+        </g>
+      </svg>
+    </Box>
+  );
+});

--- a/apps/web/src/pages/locations/MapLegend.tsx
+++ b/apps/web/src/pages/locations/MapLegend.tsx
@@ -1,0 +1,34 @@
+import { Box, Stack, Typography } from "@mui/material";
+import { memo, type ReactElement } from "react";
+
+import { floatingPanel, statusLegend } from "./constants";
+
+const legendSx = {
+  ...floatingPanel,
+  right: 16,
+  bottom: 16,
+  maxWidth: "calc(100% - 32px)",
+  backdropFilter: "blur(6px)",
+} as const;
+
+export const MapLegend = memo(function MapLegend(): ReactElement {
+  return (
+    <Stack
+      direction="row"
+      spacing={1.5}
+      flexWrap="wrap"
+      aria-label="Map status legend"
+      sx={legendSx}
+    >
+      {statusLegend.map((entry) => (
+        <Stack key={entry.label} direction="row" spacing={0.5} alignItems="center">
+          <Box
+            aria-hidden="true"
+            sx={{ width: 8, height: 8, bgcolor: entry.colour, borderRadius: "50%" }}
+          />
+          <Typography variant="caption">{entry.label}</Typography>
+        </Stack>
+      ))}
+    </Stack>
+  );
+});

--- a/apps/web/src/pages/locations/MapRegionShape.tsx
+++ b/apps/web/src/pages/locations/MapRegionShape.tsx
@@ -1,0 +1,55 @@
+import type { MapRegionView } from "@stockcontrol/contracts";
+import { memo, useSyncExternalStore, type ReactElement } from "react";
+
+import { selectionStroke, shapeStroke } from "./constants";
+import { MAP_UNITS, polylinePoints } from "./geometry";
+import type { LiveGeometryStore } from "./live-geometry-store";
+
+interface MapRegionShapeProps {
+  readonly region: MapRegionView;
+  readonly selected: boolean;
+  readonly editable: boolean;
+  readonly store: LiveGeometryStore;
+}
+
+/**
+ * One region on the map.
+ *
+ * Props are pure data — no handlers, no zoom — so this bails out of every
+ * render except its own. While a drag is running it reads the moving geometry
+ * from the live store; every other shape reads a stable `null` there and React
+ * skips it entirely, which is what keeps a drag at one component render a frame.
+ */
+export const MapRegionShape = memo(function MapRegionShape({
+  region,
+  selected,
+  editable,
+  store,
+}: MapRegionShapeProps): ReactElement {
+  const live = useSyncExternalStore(store.subscribe, () => store.getRegionGeometry(region.id));
+  const geometry = live ?? region.geometry;
+  const shared = {
+    "data-region-id": region.id,
+    id: `map-region-${region.id}`,
+    role: "button",
+    "aria-label": `${region.displayName}, ${region.stock.text}`,
+    fill: region.stock.colour,
+    fillOpacity: region.status === "Archived" ? 0.42 : 0.82,
+    stroke: selected ? selectionStroke : shapeStroke,
+    strokeWidth: selected ? 2 : 1,
+    vectorEffect: "non-scaling-stroke" as const,
+    style: { cursor: editable ? "move" : "pointer" },
+  };
+
+  return geometry.kind === "Rectangle" ? (
+    <rect
+      {...shared}
+      x={geometry.x * MAP_UNITS}
+      y={geometry.y * MAP_UNITS}
+      width={geometry.width * MAP_UNITS}
+      height={geometry.height * MAP_UNITS}
+    />
+  ) : (
+    <polygon {...shared} points={polylinePoints(geometry.points)} />
+  );
+});

--- a/apps/web/src/pages/locations/MapToolbar.tsx
+++ b/apps/web/src/pages/locations/MapToolbar.tsx
@@ -1,0 +1,191 @@
+import FitScreenRounded from "@mui/icons-material/FitScreenRounded";
+import GridOnRounded from "@mui/icons-material/GridOnRounded";
+import PanToolRounded from "@mui/icons-material/PanToolRounded";
+import PolylineRounded from "@mui/icons-material/PolylineRounded";
+import NearMeRounded from "@mui/icons-material/NearMeRounded";
+import UploadFileRounded from "@mui/icons-material/UploadFileRounded";
+import ZoomInRounded from "@mui/icons-material/ZoomInRounded";
+import ZoomOutRounded from "@mui/icons-material/ZoomOutRounded";
+import {
+  Box,
+  Button,
+  Chip,
+  IconButton,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { memo, type ReactElement } from "react";
+
+import { toggleGroupSx, toolbarGroupSx, toolbarSx } from "./constants";
+import type { EditorMode } from "./editor-state";
+
+interface MapToolbarProps {
+  readonly canEdit: boolean;
+  readonly hasMap: boolean;
+  readonly dirty: boolean;
+  readonly mode: EditorMode;
+  readonly snapEnabled: boolean;
+  readonly zoomPercentage: number;
+  readonly onModeChange: (mode: EditorMode) => void;
+  readonly onToggleSnap: () => void;
+  readonly onZoomIn: () => void;
+  readonly onZoomOut: () => void;
+  readonly onFit: () => void;
+  readonly onSave: () => void;
+  readonly onRevert: () => void;
+  readonly onUploadClick: () => void;
+}
+
+function ToolbarButton({
+  label,
+  onClick,
+  children,
+}: {
+  readonly label: string;
+  readonly onClick: () => void;
+  readonly children: ReactElement;
+}): ReactElement {
+  return (
+    <Tooltip title={label}>
+      <IconButton aria-label={label} onClick={onClick} size="small">
+        {children}
+      </IconButton>
+    </Tooltip>
+  );
+}
+
+export const MapToolbar = memo(function MapToolbar({
+  canEdit,
+  hasMap,
+  dirty,
+  mode,
+  snapEnabled,
+  zoomPercentage,
+  onModeChange,
+  onToggleSnap,
+  onZoomIn,
+  onZoomOut,
+  onFit,
+  onSave,
+  onRevert,
+  onUploadClick,
+}: MapToolbarProps): ReactElement {
+  return (
+    <Box component="nav" aria-label="Map toolbar" sx={toolbarSx}>
+      <Stack direction="row" spacing={0.5} alignItems="center" flexWrap="wrap">
+        <Box sx={toolbarGroupSx}>
+          {canEdit ? (
+            <ToggleButtonGroup
+              exclusive
+              size="small"
+              value={mode === "select" || mode === "pan" ? mode : null}
+              onChange={(_, value: EditorMode | null) => {
+                if (value !== null) onModeChange(value);
+              }}
+              aria-label="Navigation tools"
+              sx={toggleGroupSx}
+            >
+              <ToggleButton value="select" aria-label="Select mode" title="Select">
+                <NearMeRounded fontSize="small" />
+              </ToggleButton>
+              <ToggleButton value="pan" aria-label="Pan map" title="Pan (or hold space)">
+                <PanToolRounded fontSize="small" />
+              </ToggleButton>
+            </ToggleButtonGroup>
+          ) : (
+            <Chip size="small" label="View only" variant="outlined" />
+          )}
+        </Box>
+        {canEdit && (
+          <Box sx={toolbarGroupSx}>
+            <ToggleButtonGroup
+              exclusive
+              size="small"
+              value={mode === "rectangle" || mode === "polygon" ? mode : null}
+              onChange={(_, value: EditorMode | null) => {
+                if (value !== null) onModeChange(value);
+              }}
+              aria-label="Drawing tools"
+              sx={toggleGroupSx}
+            >
+              <ToggleButton value="rectangle" aria-label="Draw rectangle" title="Rectangle">
+                <Box
+                  component="span"
+                  sx={{ width: 16, height: 12, border: "2px solid currentColor" }}
+                />
+              </ToggleButton>
+              <ToggleButton value="polygon" aria-label="Draw polygon" title="Polygon">
+                <PolylineRounded fontSize="small" />
+              </ToggleButton>
+            </ToggleButtonGroup>
+          </Box>
+        )}
+        <Stack direction="row" spacing={0.25} alignItems="center">
+          <ToolbarButton label="Zoom out" onClick={onZoomOut}>
+            <ZoomOutRounded fontSize="small" />
+          </ToolbarButton>
+          <Typography
+            variant="caption"
+            aria-live="polite"
+            sx={{ minWidth: 46, textAlign: "center", fontWeight: 800, color: "text.secondary" }}
+          >
+            {String(zoomPercentage)}%
+          </Typography>
+          <ToolbarButton label="Zoom in" onClick={onZoomIn}>
+            <ZoomInRounded fontSize="small" />
+          </ToolbarButton>
+          <ToolbarButton label="Fit map to canvas" onClick={onFit}>
+            <FitScreenRounded fontSize="small" />
+          </ToolbarButton>
+        </Stack>
+        {canEdit && (
+          <ToggleButton
+            value="snap"
+            selected={snapEnabled}
+            onChange={onToggleSnap}
+            size="small"
+            aria-label="Snap to grid"
+            title="Snap to grid (hold Alt to override)"
+            sx={toggleGroupSx}
+          >
+            <GridOnRounded fontSize="small" />
+          </ToggleButton>
+        )}
+      </Stack>
+      <Stack direction="row" spacing={0.75} alignItems="center">
+        {dirty && <Chip size="small" label="Unsaved changes" color="warning" />}
+        {canEdit && hasMap && (
+          <>
+            <Button
+              size="small"
+              startIcon={<UploadFileRounded />}
+              onClick={onUploadClick}
+              sx={{ minHeight: 34, px: 1.25, display: { xs: "none", sm: "inline-flex" } }}
+            >
+              Upload floor plan
+            </Button>
+            <Button
+              size="small"
+              variant="contained"
+              onClick={onSave}
+              sx={{ minHeight: 34, px: 1.5 }}
+            >
+              Save
+            </Button>
+            <Button
+              size="small"
+              onClick={onRevert}
+              disabled={!dirty}
+              sx={{ minHeight: 34, px: 1.25, display: { xs: "none", sm: "inline-flex" } }}
+            >
+              Revert
+            </Button>
+          </>
+        )}
+      </Stack>
+    </Box>
+  );
+});

--- a/apps/web/src/pages/locations/MapWorkspace.tsx
+++ b/apps/web/src/pages/locations/MapWorkspace.tsx
@@ -1,0 +1,186 @@
+import AddRounded from "@mui/icons-material/AddRounded";
+import MapRounded from "@mui/icons-material/MapRounded";
+import { Box, Button, Stack, Typography } from "@mui/material";
+import type { MapGeometry, MapSnapshot } from "@stockcontrol/contracts";
+import { useCallback, useRef, useState, type ReactElement, type RefObject } from "react";
+
+import { emptyCanvasSx, floatingPanel } from "./constants";
+import type { EditorMode } from "./editor-state";
+import { createLiveGeometryStore } from "./live-geometry-store";
+import { MapCanvas } from "./MapCanvas";
+import { MapLegend } from "./MapLegend";
+import { MapToolbar } from "./MapToolbar";
+import { useMapViewport } from "./use-map-viewport";
+
+interface MapWorkspaceProps {
+  readonly map: MapSnapshot | null;
+  readonly canEdit: boolean;
+  readonly dirty: boolean;
+  readonly mode: EditorMode;
+  readonly snapEnabled: boolean;
+  readonly selectedRegionId: string | null;
+  readonly canCreateMap: boolean;
+  readonly svgRef: RefObject<SVGSVGElement | null>;
+  readonly onModeChange: (mode: EditorMode) => void;
+  readonly onToggleSnap: () => void;
+  readonly onSelect: (id: string | null) => void;
+  readonly onCommitGeometry: (id: string, geometry: MapGeometry) => void;
+  readonly onCreateRegion: (geometry: MapGeometry) => void;
+  readonly onRemoveRegion: (id: string) => void;
+  readonly onSave: () => void;
+  readonly onRevert: () => void;
+  readonly onUploadFile: (file: File) => void;
+  readonly onCreateMap: () => void;
+  readonly onProblem: (message: string) => void;
+}
+
+const hintSx = { ...floatingPanel, left: 16, bottom: 16, maxWidth: "min(340px, 55%)" } as const;
+
+/**
+ * Toolbar plus canvas. Owns the viewport and the live-geometry store, so pan,
+ * zoom and drags all stay below the page that loads the data.
+ */
+export function MapWorkspace({
+  map,
+  canEdit,
+  dirty,
+  mode,
+  snapEnabled,
+  selectedRegionId,
+  canCreateMap,
+  svgRef,
+  onModeChange,
+  onToggleSnap,
+  onSelect,
+  onCommitGeometry,
+  onCreateRegion,
+  onRemoveRegion,
+  onSave,
+  onRevert,
+  onUploadFile,
+  onCreateMap,
+  onProblem,
+}: MapWorkspaceProps): ReactElement {
+  const viewport = useMapViewport();
+  const [store] = useState(createLiveGeometryStore);
+  const fileInput = useRef<HTMLInputElement>(null);
+
+  const zoomIn = useCallback(() => {
+    viewport.zoomByStep(1);
+  }, [viewport]);
+  const zoomOut = useCallback(() => {
+    viewport.zoomByStep(-1);
+  }, [viewport]);
+  const openFilePicker = useCallback(() => {
+    fileInput.current?.click();
+  }, []);
+
+  return (
+    <Box
+      component="section"
+      aria-label="Building map"
+      sx={{
+        display: "grid",
+        gridTemplateRows: "auto minmax(0, 1fr)",
+        minWidth: 0,
+        minHeight: { xs: 600, lg: 0 },
+        overflow: "hidden",
+      }}
+    >
+      <MapToolbar
+        canEdit={canEdit}
+        hasMap={map !== null}
+        dirty={dirty}
+        mode={mode}
+        snapEnabled={snapEnabled}
+        zoomPercentage={viewport.zoomPercentage}
+        onModeChange={onModeChange}
+        onToggleSnap={onToggleSnap}
+        onZoomIn={zoomIn}
+        onZoomOut={zoomOut}
+        onFit={viewport.fit}
+        onSave={onSave}
+        onRevert={onRevert}
+        onUploadClick={openFilePicker}
+      />
+      <input
+        ref={fileInput}
+        hidden
+        type="file"
+        accept="image/png,image/jpeg"
+        aria-label="Upload floor plan"
+        onChange={(event) => {
+          const file = event.target.files?.[0];
+          event.target.value = "";
+          if (file !== undefined) onUploadFile(file);
+        }}
+      />
+      {map === null ? (
+        <Box sx={emptyCanvasSx}>
+          {canCreateMap ? (
+            <Stack
+              alignItems="center"
+              justifyContent="center"
+              spacing={1.25}
+              sx={{ position: "absolute", inset: 0, p: 4, textAlign: "center" }}
+            >
+              <Box
+                sx={{
+                  display: "grid",
+                  placeItems: "center",
+                  width: 52,
+                  height: 52,
+                  borderRadius: "50%",
+                  color: "primary.main",
+                  bgcolor: "#E8EEF9",
+                }}
+              >
+                <MapRounded />
+              </Box>
+              <Typography variant="h3" component="h2">
+                No storage map yet
+              </Typography>
+              <Typography color="text.secondary" sx={{ maxWidth: 420 }}>
+                Create a blank map and draw storage regions for this building.
+              </Typography>
+              <Button startIcon={<AddRounded />} variant="contained" onClick={onCreateMap}>
+                Create blank map
+              </Button>
+            </Stack>
+          ) : (
+            <Typography
+              color="text.secondary"
+              sx={{ position: "absolute", inset: 0, display: "grid", placeItems: "center" }}
+            >
+              Loading map…
+            </Typography>
+          )}
+        </Box>
+      ) : (
+        <Box sx={{ position: "relative", minWidth: 0, minHeight: 0 }}>
+          <MapCanvas
+            map={map}
+            canEdit={canEdit}
+            mode={mode}
+            snapEnabled={snapEnabled}
+            selectedRegionId={selectedRegionId}
+            store={store}
+            viewport={viewport}
+            svgRef={svgRef}
+            onSelect={onSelect}
+            onCommitGeometry={onCommitGeometry}
+            onCreateRegion={onCreateRegion}
+            onRemoveRegion={onRemoveRegion}
+            onProblem={onProblem}
+          />
+          {mode === "polygon" && (
+            <Typography variant="caption" color="text.secondary" sx={hintSx}>
+              Click to add points. Click the first point or press Enter to finish.
+            </Typography>
+          )}
+          <MapLegend />
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/apps/web/src/pages/locations/RegionInspector.tsx
+++ b/apps/web/src/pages/locations/RegionInspector.tsx
@@ -1,0 +1,272 @@
+import ArchiveRounded from "@mui/icons-material/ArchiveRounded";
+import ArrowDownwardRounded from "@mui/icons-material/ArrowDownwardRounded";
+import ArrowUpwardRounded from "@mui/icons-material/ArrowUpwardRounded";
+import CheckCircleRounded from "@mui/icons-material/CheckCircleRounded";
+import CloseRounded from "@mui/icons-material/CloseRounded";
+import DeleteOutlineRounded from "@mui/icons-material/DeleteOutlineRounded";
+import MapRounded from "@mui/icons-material/MapRounded";
+import RemoveCircleOutlineRounded from "@mui/icons-material/RemoveCircleOutlineRounded";
+import WarningAmberRounded from "@mui/icons-material/WarningAmberRounded";
+import {
+  Box,
+  Button,
+  Chip,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import type { HierarchyNodeView, MapRegionView } from "@stockcontrol/contracts";
+import { memo, type ReactElement } from "react";
+
+import { panelBorder } from "./constants";
+import type { RegionChanges } from "./editor-state";
+import { geometrySummary } from "./geometry";
+
+interface RegionInspectorProps {
+  readonly region: MapRegionView | null;
+  readonly canEdit: boolean;
+  readonly dirty: boolean;
+  readonly locationCode: string;
+  readonly nodeOptions: readonly HierarchyNodeView[];
+  readonly parentOptions: readonly MapRegionView[];
+  readonly onPatch: (id: string, changes: RegionChanges) => void;
+  readonly onReorder: (id: string, direction: "raise" | "lower") => void;
+  readonly onRemove: (id: string) => void;
+  readonly onClose: () => void;
+  readonly onSave: () => void;
+}
+
+const sectionSx = { pb: 1.75, borderBottom: `1px solid ${panelBorder}` } as const;
+const actionSx = { minHeight: 36, px: 1.25 } as const;
+
+function StockStatusIcon({ status }: { readonly status: string }): ReactElement {
+  if (status === "Available") return <CheckCircleRounded fontSize="small" />;
+  if (status === "LowStock") return <WarningAmberRounded fontSize="small" />;
+  if (status === "Archived") return <ArchiveRounded fontSize="small" />;
+  return <RemoveCircleOutlineRounded fontSize="small" />;
+}
+
+export const RegionInspector = memo(function RegionInspector({
+  region,
+  canEdit,
+  dirty,
+  locationCode,
+  nodeOptions,
+  parentOptions,
+  onPatch,
+  onReorder,
+  onRemove,
+  onClose,
+  onSave,
+}: RegionInspectorProps): ReactElement {
+  return (
+    <Box sx={{ p: 1.75 }}>
+      <Stack direction="row" justifyContent="space-between" alignItems="start">
+        <Box>
+          <Typography variant="overline" color="text.secondary">
+            Region details
+          </Typography>
+          {region !== null && (
+            <>
+              <Typography variant="h3" component="h2" sx={{ mt: 0.25 }}>
+                {region.displayName}
+              </Typography>
+              <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 700 }}>
+                {locationCode}
+              </Typography>
+            </>
+          )}
+        </Box>
+        <IconButton size="small" aria-label="Close region details" onClick={onClose}>
+          <CloseRounded fontSize="small" />
+        </IconButton>
+      </Stack>
+      {region === null ? (
+        <Stack spacing={1.25} sx={{ pt: 7, pb: 5 }}>
+          <MapRounded color="primary" sx={{ fontSize: 36 }} />
+          <Typography sx={{ fontWeight: 800 }}>Nothing selected</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Select a region on the map to view its assigned location, stock status, item quantities
+            and dimensions.
+          </Typography>
+        </Stack>
+      ) : (
+        <Stack spacing={1.75} sx={{ mt: 1.5 }}>
+          <Box sx={sectionSx}>
+            <Typography variant="overline" color="text.secondary">
+              Stock status
+            </Typography>
+            <Chip
+              icon={<StockStatusIcon status={region.stock.status} />}
+              label={region.stock.text}
+              sx={{
+                mt: 0.75,
+                alignSelf: "start",
+                bgcolor: region.stock.colour,
+                color: "#fff",
+                "& .MuiChip-icon": { color: "inherit" },
+              }}
+            />
+            <Stack direction="row" spacing={2.5} sx={{ mt: 1.5 }}>
+              <Box>
+                <Typography variant="h4">{region.stock.itemCount}</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  item types
+                </Typography>
+              </Box>
+              <Box>
+                <Typography variant="h4">{region.stock.quantity}</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  total units
+                </Typography>
+              </Box>
+            </Stack>
+          </Box>
+          <Box sx={sectionSx}>
+            <Typography variant="overline" color="text.secondary">
+              Mapped area
+            </Typography>
+            <Typography variant="body2" sx={{ mt: 0.5, fontWeight: 700 }}>
+              {geometrySummary(region.geometry)}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Drag the region or its corner handles, or nudge it with the arrow keys.
+            </Typography>
+          </Box>
+          {canEdit && (
+            <Stack spacing={1.25}>
+              <Typography variant="overline" color="text.secondary">
+                Properties
+              </Typography>
+              <TextField
+                fullWidth
+                label="Region name"
+                size="small"
+                value={region.displayName}
+                onChange={(event) => {
+                  onPatch(region.id, { displayName: event.target.value });
+                }}
+              />
+              <FormControl fullWidth size="small">
+                <InputLabel id="region-location-label">Location assignment</InputLabel>
+                <Select
+                  labelId="region-location-label"
+                  label="Location assignment"
+                  value={region.hierarchyNodeId}
+                  onChange={(event) => {
+                    onPatch(region.id, { hierarchyNodeId: event.target.value });
+                  }}
+                >
+                  {nodeOptions.map((node) => (
+                    <MenuItem key={node.id} value={node.id}>
+                      {node.name} · {node.code}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <FormControl fullWidth size="small">
+                <InputLabel id="region-parent-label">Visual parent</InputLabel>
+                <Select
+                  labelId="region-parent-label"
+                  label="Visual parent"
+                  value={region.parentRegionId ?? "none"}
+                  onChange={(event) => {
+                    onPatch(region.id, {
+                      parentRegionId: event.target.value === "none" ? null : event.target.value,
+                    });
+                  }}
+                >
+                  <MenuItem value="none">None</MenuItem>
+                  {parentOptions.map((candidate) => (
+                    <MenuItem key={candidate.id} value={candidate.id}>
+                      {candidate.displayName}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <TextField
+                fullWidth
+                label="Search aliases"
+                size="small"
+                value={region.searchAliases.join(", ")}
+                helperText="Separate aliases with commas"
+                onChange={(event) => {
+                  onPatch(region.id, {
+                    searchAliases: event.target.value
+                      .split(",")
+                      .map((alias) => alias.trim())
+                      .filter((alias) => alias.length > 0),
+                  });
+                }}
+              />
+              <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
+                <Button
+                  size="small"
+                  startIcon={<ArrowUpwardRounded />}
+                  onClick={() => {
+                    onReorder(region.id, "raise");
+                  }}
+                  sx={actionSx}
+                >
+                  Raise
+                </Button>
+                <Button
+                  size="small"
+                  startIcon={<ArrowDownwardRounded />}
+                  onClick={() => {
+                    onReorder(region.id, "lower");
+                  }}
+                  sx={actionSx}
+                >
+                  Lower
+                </Button>
+                <Button
+                  size="small"
+                  color="error"
+                  startIcon={<ArchiveRounded />}
+                  onClick={() => {
+                    onPatch(region.id, {
+                      status: region.status === "Archived" ? "Active" : "Archived",
+                    });
+                  }}
+                  sx={actionSx}
+                >
+                  {region.status === "Archived" ? "Restore" : "Archive"}
+                </Button>
+                <Button
+                  size="small"
+                  color="error"
+                  variant="outlined"
+                  startIcon={<DeleteOutlineRounded />}
+                  onClick={() => {
+                    onRemove(region.id);
+                  }}
+                  sx={actionSx}
+                >
+                  Delete
+                </Button>
+              </Stack>
+              <Button
+                fullWidth
+                variant="contained"
+                onClick={onSave}
+                disabled={!dirty}
+                sx={{ mt: 0.5 }}
+              >
+                Save changes
+              </Button>
+              <Typography variant="caption" color="text.secondary">
+                Arrow keys move the selected region, Shift + Arrow moves farther, Delete removes it.
+              </Typography>
+            </Stack>
+          )}
+        </Stack>
+      )}
+    </Box>
+  );
+});

--- a/apps/web/src/pages/locations/SelectionHandles.tsx
+++ b/apps/web/src/pages/locations/SelectionHandles.tsx
@@ -1,0 +1,65 @@
+import type { MapRegionView } from "@stockcontrol/contracts";
+import { memo, useSyncExternalStore, type ReactElement } from "react";
+
+import { selectionStroke } from "./constants";
+import { MAP_UNITS, type ResizeHandle } from "./geometry";
+import type { LiveGeometryStore } from "./live-geometry-store";
+
+interface SelectionHandlesProps {
+  readonly region: MapRegionView;
+  readonly scale: number;
+  readonly store: LiveGeometryStore;
+}
+
+/** Handle size in screen pixels, so the grab target does not shrink when zoomed out. */
+const HANDLE_RADIUS_PIXELS = 6;
+
+const cursorFor: Readonly<Record<ResizeHandle, string>> = {
+  nw: "nwse-resize",
+  ne: "nesw-resize",
+  sw: "nesw-resize",
+  se: "nwse-resize",
+};
+
+/**
+ * Corner handles for the selected rectangle. Split from the shape so that a
+ * zoom, which changes the handle radius, re-renders only this one component
+ * rather than every region on the map.
+ */
+export const SelectionHandles = memo(function SelectionHandles({
+  region,
+  scale,
+  store,
+}: SelectionHandlesProps): ReactElement | null {
+  const live = useSyncExternalStore(store.subscribe, () => store.getRegionGeometry(region.id));
+  const geometry = live ?? region.geometry;
+  if (geometry.kind !== "Rectangle") return null;
+
+  const radius = HANDLE_RADIUS_PIXELS / scale;
+  const corners: readonly (readonly [ResizeHandle, number, number])[] = [
+    ["nw", geometry.x, geometry.y],
+    ["ne", geometry.x + geometry.width, geometry.y],
+    ["sw", geometry.x, geometry.y + geometry.height],
+    ["se", geometry.x + geometry.width, geometry.y + geometry.height],
+  ];
+
+  return (
+    <g aria-hidden="true">
+      {corners.map(([handle, x, y]) => (
+        <circle
+          key={handle}
+          data-handle={handle}
+          data-handle-region={region.id}
+          cx={x * MAP_UNITS}
+          cy={y * MAP_UNITS}
+          r={radius}
+          fill="#FFFFFF"
+          stroke={selectionStroke}
+          strokeWidth={1.5}
+          vectorEffect="non-scaling-stroke"
+          style={{ cursor: cursorFor[handle] }}
+        />
+      ))}
+    </g>
+  );
+});

--- a/apps/web/src/pages/locations/constants.ts
+++ b/apps/web/src/pages/locations/constants.ts
@@ -1,0 +1,91 @@
+import type { SxProps, Theme } from "@mui/material";
+
+/**
+ * Style objects and palette values hoisted out of render.
+ *
+ * MUI's `sx` prop is serialised by Emotion every time it receives a fresh
+ * object, which is why the old page paid for the whole hierarchy tree's styles
+ * on every pointer move. Module constants are serialised once.
+ */
+
+export const mapBorder = "#D9E0E9";
+export const panelBorder = "#E2E7EE";
+export const canvasBackground = "#F8FAFC";
+export const gridLine = "#DFE5EE";
+export const selectionStroke = "#071B3A";
+export const shapeStroke = "#FFFFFF";
+
+export const statusLegend = [
+  { colour: "#2E7D32", label: "Available" },
+  { colour: "#ED6C02", label: "Low stock" },
+  { colour: "#D32F2F", label: "Out of stock" },
+  { colour: "#757575", label: "Archived" },
+] as const;
+
+export const floatingPanel: SxProps<Theme> = {
+  position: "absolute",
+  px: 1.25,
+  py: 0.75,
+  border: "1px solid #D8DEE8",
+  borderRadius: 1,
+  bgcolor: "rgba(255,255,255,0.92)",
+  boxShadow: "0 4px 14px rgba(19,36,65,0.08)",
+};
+
+export const toolbarSx: SxProps<Theme> = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: 1,
+  minHeight: 48,
+  px: 1.25,
+  py: 0.75,
+  borderBottom: `1px solid ${mapBorder}`,
+  bgcolor: "#FFFFFF",
+  flexWrap: "wrap",
+};
+
+export const toolbarGroupSx: SxProps<Theme> = {
+  display: "flex",
+  alignItems: "center",
+  gap: 0.25,
+  pr: 1,
+  mr: 0.5,
+  borderRight: `1px solid ${panelBorder}`,
+};
+
+export const toggleGroupSx: SxProps<Theme> = { height: 34 };
+
+export const canvasSurfaceSx: SxProps<Theme> = {
+  /*
+   * Absolute, not just relative: an `<svg>` whose parent has no resolved height
+   * falls back to the SVG default of 150px, which collapses the whole editor.
+   */
+  position: "absolute",
+  inset: 0,
+  overflow: "hidden",
+  bgcolor: canvasBackground,
+};
+
+export const emptyCanvasSx: SxProps<Theme> = {
+  position: "relative",
+  minWidth: 0,
+  minHeight: 0,
+  overflow: "hidden",
+  bgcolor: canvasBackground,
+  borderTop: `1px solid ${mapBorder}`,
+};
+
+export const treeItemSlotProps = {
+  primary: {
+    noWrap: true,
+    fontSize: "0.84rem",
+    fontWeight: 700,
+    color: "#17243B",
+  },
+  secondary: {
+    noWrap: true,
+    fontSize: "0.72rem",
+    color: "#667085",
+  },
+} as const;

--- a/apps/web/src/pages/locations/editor-state.test.ts
+++ b/apps/web/src/pages/locations/editor-state.test.ts
@@ -1,0 +1,238 @@
+import type { MapRegionView, MapSnapshot } from "@stockcontrol/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+  editorReducer,
+  flattenHierarchy,
+  initialEditor,
+  sortedByZOrder,
+  toInputs,
+  type EditorState,
+} from "./editor-state";
+import {
+  testBranch,
+  testMapSnapshot,
+  testPolygonRegionId,
+  testRectangleRegionId,
+} from "../../test/fake-api";
+
+const loaded: EditorState = editorReducer(initialEditor, {
+  type: "load",
+  map: testMapSnapshot,
+});
+
+const regionsOf = (state: EditorState): readonly MapRegionView[] => state.draft?.regions ?? [];
+const regionIn = (state: EditorState, id: string): MapRegionView | undefined =>
+  regionsOf(state).find((region) => region.id === id);
+
+describe("load and revert", () => {
+  it("starts clean with both copies pointing at the loaded map", () => {
+    expect(loaded.draft).toBe(testMapSnapshot);
+    expect(loaded.persisted).toBe(testMapSnapshot);
+    expect(loaded.dirty).toBe(false);
+    expect(loaded.selectedRegionId).toBeNull();
+  });
+
+  it("throws away edits and the selection on revert", () => {
+    const edited = editorReducer(loaded, {
+      type: "patch-region",
+      id: testRectangleRegionId,
+      changes: { displayName: "Renamed" },
+    });
+    const reverted = editorReducer(edited, { type: "revert" });
+
+    expect(edited.dirty).toBe(true);
+    expect(reverted.draft).toBe(testMapSnapshot);
+    expect(reverted.dirty).toBe(false);
+  });
+
+  it("keeps identity when a no-op action arrives, so memoised children can bail", () => {
+    expect(editorReducer(loaded, { type: "select", id: null })).toBe(loaded);
+    expect(editorReducer(loaded, { type: "mode", mode: "select" })).toBe(loaded);
+  });
+});
+
+describe("add-region", () => {
+  const geometry = { kind: "Rectangle", x: 0.5, y: 0.5, width: 0.2, height: 0.2 } as const;
+
+  it("selects the new region and returns to the select tool", () => {
+    const added = editorReducer(loaded, { type: "add-region", geometry });
+
+    expect(regionsOf(added)).toHaveLength(3);
+    expect(added.mode).toBe("select");
+    expect(added.selectedRegionId).toBe(regionsOf(added)[2]?.id);
+    expect(added.dirty).toBe(true);
+  });
+
+  it("puts each new region on top with a safe integer z-order", () => {
+    const added = editorReducer(loaded, { type: "add-region", geometry });
+    const zOrder = regionsOf(added)[2]?.zOrder ?? 0;
+
+    expect(zOrder).toBe(3);
+    expect(Number.isSafeInteger(zOrder)).toBe(true);
+  });
+
+  it("gives regions created in the same millisecond distinct identities", () => {
+    /*
+     * The old editor keyed drafts on Date.now(), so two shapes drawn quickly
+     * collided and silently merged on save.
+     */
+    const first = editorReducer(loaded, { type: "add-region", geometry });
+    const second = editorReducer(first, { type: "add-region", geometry });
+    const ids = regionsOf(second).map((region) => region.id);
+
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("commit-geometry", () => {
+  it("replaces only the geometry of the region that moved", () => {
+    const geometry = { kind: "Rectangle", x: 0.4, y: 0.4, width: 0.1, height: 0.1 } as const;
+    const moved = editorReducer(loaded, {
+      type: "commit-geometry",
+      id: testRectangleRegionId,
+      geometry,
+    });
+
+    expect(regionIn(moved, testRectangleRegionId)?.geometry).toBe(geometry);
+    expect(regionIn(moved, testPolygonRegionId)).toBe(regionIn(loaded, testPolygonRegionId));
+    expect(moved.dirty).toBe(true);
+  });
+});
+
+describe("archiving", () => {
+  const nested: MapSnapshot = {
+    ...testMapSnapshot,
+    regions: [
+      testMapSnapshot.regions[0]!,
+      { ...testMapSnapshot.regions[1]!, parentRegionId: testRectangleRegionId },
+    ],
+  };
+  const withNesting = editorReducer(initialEditor, { type: "load", map: nested });
+
+  it("archives descendants too, because the server refuses an active child", () => {
+    const archived = editorReducer(withNesting, {
+      type: "patch-region",
+      id: testRectangleRegionId,
+      changes: { status: "Archived" },
+    });
+
+    expect(regionIn(archived, testPolygonRegionId)?.status).toBe("Archived");
+  });
+
+  it("detaches a restored region from a parent that is still archived", () => {
+    const archived = editorReducer(withNesting, {
+      type: "patch-region",
+      id: testRectangleRegionId,
+      changes: { status: "Archived" },
+    });
+    const restored = editorReducer(archived, {
+      type: "patch-region",
+      id: testPolygonRegionId,
+      changes: { status: "Active" },
+    });
+
+    expect(regionIn(restored, testPolygonRegionId)?.status).toBe("Active");
+    expect(regionIn(restored, testPolygonRegionId)?.parentRegionId).toBeNull();
+  });
+});
+
+describe("remove-region", () => {
+  it("clears the link on children so the save is not rejected as an orphan", () => {
+    const nested: MapSnapshot = {
+      ...testMapSnapshot,
+      regions: [
+        testMapSnapshot.regions[0]!,
+        { ...testMapSnapshot.regions[1]!, parentRegionId: testRectangleRegionId },
+      ],
+    };
+    const removed = editorReducer(editorReducer(initialEditor, { type: "load", map: nested }), {
+      type: "remove-region",
+      id: testRectangleRegionId,
+    });
+
+    expect(regionsOf(removed)).toHaveLength(1);
+    expect(regionIn(removed, testPolygonRegionId)?.parentRegionId).toBeNull();
+  });
+
+  it("drops the selection when the selected region goes", () => {
+    const selected = editorReducer(loaded, { type: "select", id: testRectangleRegionId });
+    const removed = editorReducer(selected, { type: "remove-region", id: testRectangleRegionId });
+
+    expect(removed.selectedRegionId).toBeNull();
+  });
+});
+
+describe("reorder-region", () => {
+  it("raises above every other region and lowers below them", () => {
+    const raised = editorReducer(loaded, {
+      type: "reorder-region",
+      id: testRectangleRegionId,
+      direction: "raise",
+    });
+    const lowered = editorReducer(loaded, {
+      type: "reorder-region",
+      id: testPolygonRegionId,
+      direction: "lower",
+    });
+
+    expect(sortedByZOrder(regionsOf(raised)).at(-1)?.id).toBe(testRectangleRegionId);
+    expect(sortedByZOrder(regionsOf(lowered))[0]?.id).toBe(testPolygonRegionId);
+  });
+
+  it("keeps z-order a safe integer, which the domain requires", () => {
+    const raised = editorReducer(loaded, {
+      type: "reorder-region",
+      id: testRectangleRegionId,
+      direction: "raise",
+    });
+
+    for (const region of regionsOf(raised)) expect(Number.isSafeInteger(region.zOrder)).toBe(true);
+  });
+});
+
+describe("toInputs", () => {
+  it("sends every region with its identity so links survive the save", () => {
+    const geometry = { kind: "Rectangle", x: 0.5, y: 0.5, width: 0.2, height: 0.2 } as const;
+    const added = editorReducer(loaded, { type: "add-region", geometry });
+    const drawnId = regionsOf(added)[2]?.id ?? "";
+    const linked = editorReducer(added, {
+      type: "patch-region",
+      id: testPolygonRegionId,
+      changes: { parentRegionId: drawnId },
+    });
+    const inputs = toInputs(linked.draft!);
+
+    expect(inputs.map((input) => input.id)).toEqual([
+      testRectangleRegionId,
+      testPolygonRegionId,
+      drawnId,
+    ]);
+    /* The new region can be a visual parent because it already has a real id. */
+    expect(inputs[1]?.parentRegionId).toBe(drawnId);
+  });
+
+  it("carries every field the save contract needs", () => {
+    expect(toInputs(testMapSnapshot)[0]).toEqual({
+      id: testRectangleRegionId,
+      displayName: "Aisle A bays",
+      hierarchyNodeId: testMapSnapshot.regions[0]!.hierarchyNodeId,
+      parentRegionId: null,
+      geometry: testMapSnapshot.regions[0]!.geometry,
+      zOrder: 1,
+      searchAliases: ["bay row"],
+      status: "Active",
+    });
+  });
+});
+
+describe("flattenHierarchy", () => {
+  it("walks the whole tree depth first", () => {
+    expect(flattenHierarchy([testBranch]).map((node) => node.code)).toEqual([
+      "BR",
+      "MAIN",
+      "MAIN-A",
+      "MAIN-B",
+    ]);
+  });
+});

--- a/apps/web/src/pages/locations/editor-state.ts
+++ b/apps/web/src/pages/locations/editor-state.ts
@@ -1,0 +1,234 @@
+import type {
+  HierarchyNodeView,
+  MapGeometry,
+  MapRegionInput,
+  MapRegionView,
+  MapSnapshot,
+} from "@stockcontrol/contracts";
+
+/**
+ * The map editor's committed state. Everything here changes at most once per
+ * gesture — in-flight drag geometry lives in `live-geometry-store` instead, so
+ * moving a region does not re-render the page sixty times a second.
+ */
+
+export type EditorMode = "select" | "rectangle" | "polygon" | "pan";
+export type RegionChanges = Partial<Omit<MapRegionView, "id" | "geometry">>;
+
+export interface EditorState {
+  readonly persisted: MapSnapshot | null;
+  readonly draft: MapSnapshot | null;
+  readonly selectedRegionId: string | null;
+  readonly mode: EditorMode;
+  readonly snapEnabled: boolean;
+  readonly dirty: boolean;
+}
+
+export type EditorAction =
+  | { readonly type: "load"; readonly map: MapSnapshot }
+  | { readonly type: "saved"; readonly map: MapSnapshot }
+  | { readonly type: "select"; readonly id: string | null }
+  | { readonly type: "mode"; readonly mode: EditorMode }
+  | { readonly type: "toggle-snap" }
+  | { readonly type: "revert" }
+  | { readonly type: "add-region"; readonly geometry: MapGeometry }
+  | { readonly type: "patch-region"; readonly id: string; readonly changes: RegionChanges }
+  | { readonly type: "commit-geometry"; readonly id: string; readonly geometry: MapGeometry }
+  | { readonly type: "remove-region"; readonly id: string }
+  | {
+      readonly type: "reorder-region";
+      readonly id: string;
+      readonly direction: "raise" | "lower";
+    };
+
+export const initialEditor: EditorState = {
+  persisted: null,
+  draft: null,
+  selectedRegionId: null,
+  mode: "select",
+  snapEnabled: true,
+  dirty: false,
+};
+
+const newRegionStock: MapRegionView["stock"] = {
+  status: "OutOfStock",
+  colour: "#D32F2F",
+  text: "Out of stock",
+  icon: "remove-circle",
+  itemCount: 0,
+  quantity: "0",
+};
+
+/**
+ * New regions get a canonical UUID up front rather than a `draft-` placeholder.
+ * The server accepts a client-supplied region id (`createMapRegionId`), so a
+ * region keeps its identity across the save and — unlike the placeholder — can
+ * be referenced as another region's visual parent in the same payload.
+ */
+export const createRegionId = (): string => globalThis.crypto.randomUUID();
+
+export const flattenHierarchy = (
+  nodes: readonly HierarchyNodeView[],
+): readonly HierarchyNodeView[] =>
+  nodes.flatMap((node) => [node, ...flattenHierarchy(node.children)]);
+
+/** Paint order. The inspector's Raise and Lower had no effect without this. */
+export const sortedByZOrder = (regions: readonly MapRegionView[]): readonly MapRegionView[] =>
+  [...regions].sort((left, right) => left.zOrder - right.zOrder);
+
+export const toInputs = (map: MapSnapshot): readonly MapRegionInput[] =>
+  map.regions.map((region) => ({
+    id: region.id,
+    displayName: region.displayName,
+    hierarchyNodeId: region.hierarchyNodeId,
+    parentRegionId: region.parentRegionId,
+    geometry: region.geometry,
+    zOrder: region.zOrder,
+    searchAliases: region.searchAliases,
+    status: region.status,
+  }));
+
+const descendantsOf = (regions: readonly MapRegionView[], id: string): ReadonlySet<string> => {
+  const found = new Set<string>();
+  let added = true;
+  while (added) {
+    added = false;
+    for (const region of regions) {
+      if (region.parentRegionId === null || found.has(region.id)) continue;
+      if (region.parentRegionId === id || found.has(region.parentRegionId)) {
+        found.add(region.id);
+        added = true;
+      }
+    }
+  }
+  return found;
+};
+
+const withRegions = (state: EditorState, regions: readonly MapRegionView[]): EditorState =>
+  state.draft === null ? state : { ...state, draft: { ...state.draft, regions }, dirty: true };
+
+/**
+ * The server rejects an active region under an archived parent, and an archived
+ * region whose children are still active, so archiving cascades downwards and
+ * restoring detaches from a still-archived parent.
+ */
+const applyStatus = (
+  regions: readonly MapRegionView[],
+  id: string,
+  status: MapRegionView["status"],
+): readonly MapRegionView[] => {
+  if (status === "Archived") {
+    const affected = descendantsOf(regions, id);
+    return regions.map((region) =>
+      region.id === id || affected.has(region.id) ? { ...region, status } : region,
+    );
+  }
+  const archived = new Set(
+    regions.filter((region) => region.status === "Archived").map((region) => region.id),
+  );
+  return regions.map((region) =>
+    region.id === id
+      ? {
+          ...region,
+          status,
+          parentRegionId:
+            region.parentRegionId !== null && archived.has(region.parentRegionId)
+              ? null
+              : region.parentRegionId,
+        }
+      : region,
+  );
+};
+
+export function editorReducer(state: EditorState, action: EditorAction): EditorState {
+  switch (action.type) {
+    case "load":
+      return {
+        ...state,
+        persisted: action.map,
+        draft: action.map,
+        dirty: false,
+        selectedRegionId: null,
+      };
+    case "saved":
+      return { ...state, persisted: action.map, draft: action.map, dirty: false };
+    case "select":
+      return state.selectedRegionId === action.id
+        ? state
+        : { ...state, selectedRegionId: action.id };
+    case "mode":
+      return state.mode === action.mode ? state : { ...state, mode: action.mode };
+    case "toggle-snap":
+      return { ...state, snapEnabled: !state.snapEnabled };
+    case "revert":
+      return { ...state, draft: state.persisted, dirty: false, selectedRegionId: null };
+    case "add-region": {
+      if (state.draft === null) return state;
+      const id = createRegionId();
+      const orders = state.draft.regions.map((region) => Math.round(region.zOrder));
+      const region: MapRegionView = {
+        id,
+        displayName: "New region",
+        hierarchyNodeId: state.draft.buildingId,
+        parentRegionId: null,
+        geometry: action.geometry,
+        zOrder: orders.length === 0 ? 1 : Math.max(...orders) + 1,
+        searchAliases: [],
+        status: "Active",
+        stock: newRegionStock,
+      };
+      return {
+        ...withRegions(state, [...state.draft.regions, region]),
+        selectedRegionId: id,
+        mode: "select",
+      };
+    }
+    case "patch-region": {
+      if (state.draft === null) return state;
+      const { status, ...rest } = action.changes;
+      const staged =
+        status === undefined
+          ? state.draft.regions
+          : applyStatus(state.draft.regions, action.id, status);
+      return withRegions(
+        state,
+        staged.map((region) => (region.id === action.id ? { ...region, ...rest } : region)),
+      );
+    }
+    case "commit-geometry":
+      if (state.draft === null) return state;
+      return withRegions(
+        state,
+        state.draft.regions.map((region) =>
+          region.id === action.id ? { ...region, geometry: action.geometry } : region,
+        ),
+      );
+    case "remove-region": {
+      if (state.draft === null) return state;
+      /* Children must lose the link or the server refuses the save as an orphan. */
+      const regions = state.draft.regions
+        .filter((region) => region.id !== action.id)
+        .map((region) =>
+          region.parentRegionId === action.id ? { ...region, parentRegionId: null } : region,
+        );
+      return {
+        ...withRegions(state, regions),
+        selectedRegionId: state.selectedRegionId === action.id ? null : state.selectedRegionId,
+      };
+    }
+    case "reorder-region": {
+      if (state.draft === null || state.draft.regions.length === 0) return state;
+      const orders = state.draft.regions.map((region) => Math.round(region.zOrder));
+      const zOrder =
+        action.direction === "raise" ? Math.max(...orders) + 1 : Math.min(...orders) - 1;
+      return withRegions(
+        state,
+        state.draft.regions.map((region) =>
+          region.id === action.id ? { ...region, zOrder } : region,
+        ),
+      );
+    }
+    default:
+      return state;
+  }
+}

--- a/apps/web/src/pages/locations/geometry.test.ts
+++ b/apps/web/src/pages/locations/geometry.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MIN_REGION_SIZE,
+  boundsOf,
+  moveGeometry,
+  polygonProblem,
+  polylinePoints,
+  rectangleFromPoints,
+  resizeRectangle,
+  snapGeometry,
+  snapPoint,
+  snapValue,
+  unionBounds,
+  type PolygonGeometry,
+  type RectangleGeometry,
+} from "./geometry";
+
+const rectangle = (x: number, y: number, width: number, height: number): RectangleGeometry => ({
+  kind: "Rectangle",
+  x,
+  y,
+  width,
+  height,
+});
+
+const polygon = (points: readonly { x: number; y: number }[]): PolygonGeometry => ({
+  kind: "Polygon",
+  points,
+});
+
+/** Compares geometry without tripping over binary-float noise. */
+function expectRectangle(actual: RectangleGeometry | null, expected: RectangleGeometry): void {
+  expect(actual).not.toBeNull();
+  expect(actual?.x).toBeCloseTo(expected.x, 9);
+  expect(actual?.y).toBeCloseTo(expected.y, 9);
+  expect(actual?.width).toBeCloseTo(expected.width, 9);
+  expect(actual?.height).toBeCloseTo(expected.height, 9);
+}
+
+describe("moveGeometry", () => {
+  it("moves a rectangle by the delta", () => {
+    expectRectangle(
+      moveGeometry(rectangle(0.1, 0.2, 0.3, 0.4), 0.05, -0.1) as RectangleGeometry,
+      rectangle(0.15, 0.1, 0.3, 0.4),
+    );
+  });
+
+  it("stops a rectangle at the canvas edges", () => {
+    expect(moveGeometry(rectangle(0.8, 0.8, 0.3, 0.3), 1, 1)).toEqual(
+      rectangle(0.7, 0.7, 0.3, 0.3),
+    );
+    expect(moveGeometry(rectangle(0.1, 0.1, 0.2, 0.2), -1, -1)).toEqual(rectangle(0, 0, 0.2, 0.2));
+  });
+
+  it("moves a polygon as a body without distorting it at the edge", () => {
+    const moved = moveGeometry(
+      polygon([
+        { x: 0.5, y: 0.5 },
+        { x: 0.7, y: 0.5 },
+        { x: 0.6, y: 0.7 },
+      ]),
+      1,
+      0,
+    );
+    const bounds = boundsOf(moved);
+
+    /* The delta is capped so the right edge lands on the canvas edge, not past it. */
+    expect(bounds.maxX).toBeCloseTo(1, 9);
+    expect(bounds.maxX - bounds.minX).toBeCloseTo(0.2, 9);
+    expect(bounds.minY).toBeCloseTo(0.5, 9);
+  });
+});
+
+describe("resizeRectangle", () => {
+  const base = rectangle(0.2, 0.2, 0.4, 0.4);
+
+  it("moves only the edges the handle owns", () => {
+    expectRectangle(resizeRectangle(base, "se", { x: 0.8, y: 0.9 }), rectangle(0.2, 0.2, 0.6, 0.7));
+    expectRectangle(
+      resizeRectangle(base, "nw", { x: 0.1, y: 0.05 }),
+      rectangle(0.1, 0.05, 0.5, 0.55),
+    );
+    expectRectangle(resizeRectangle(base, "ne", { x: 0.9, y: 0.1 }), rectangle(0.2, 0.1, 0.7, 0.5));
+    expectRectangle(resizeRectangle(base, "sw", { x: 0.1, y: 0.9 }), rectangle(0.1, 0.2, 0.5, 0.7));
+  });
+
+  it("never shrinks below the minimum region size on any handle", () => {
+    for (const handle of ["nw", "ne", "sw", "se"] as const) {
+      const resized = resizeRectangle(base, handle, { x: 0.4, y: 0.4 });
+      expect(resized.width).toBeGreaterThanOrEqual(MIN_REGION_SIZE - 1e-9);
+      expect(resized.height).toBeGreaterThanOrEqual(MIN_REGION_SIZE - 1e-9);
+    }
+  });
+
+  it("keeps the result inside the canvas", () => {
+    const resized = resizeRectangle(base, "se", { x: 5, y: 5 });
+    expect(resized.x + resized.width).toBeLessThanOrEqual(1);
+    expect(resized.y + resized.height).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("rectangleFromPoints", () => {
+  it("normalises a drag made right-to-left and bottom-to-top", () => {
+    expectRectangle(
+      rectangleFromPoints({ x: 0.6, y: 0.7 }, { x: 0.2, y: 0.3 }),
+      rectangle(0.2, 0.3, 0.4, 0.4),
+    );
+  });
+
+  it("treats a stray click as no rectangle at all", () => {
+    expect(rectangleFromPoints({ x: 0.4, y: 0.4 }, { x: 0.401, y: 0.402 })).toBeNull();
+  });
+
+  it("raises a thin drag to the minimum region size", () => {
+    const drawn = rectangleFromPoints({ x: 0.4, y: 0.4 }, { x: 0.6, y: 0.402 });
+    expect(drawn?.height).toBe(MIN_REGION_SIZE);
+  });
+
+  it("keeps a drag that leaves the canvas inside it", () => {
+    const drawn = rectangleFromPoints({ x: 0.95, y: 0.95 }, { x: 1.4, y: 1.4 });
+    expect(drawn).not.toBeNull();
+    expect((drawn?.x ?? 0) + (drawn?.width ?? 0)).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("snapping", () => {
+  it("rounds to the grid without binary-float noise", () => {
+    expect(snapValue(0.3049, 0.01)).toBe(0.3);
+    expect(snapValue(0.307, 0.01)).toBe(0.31);
+    expect(snapPoint({ x: 0.1234, y: 0.5678 }, 0.01)).toEqual({ x: 0.12, y: 0.57 });
+  });
+
+  it("aligns a shape's corner to the grid without changing its size", () => {
+    expectRectangle(
+      snapGeometry(rectangle(0.123, 0.456, 0.3, 0.2), 0.01) as RectangleGeometry,
+      rectangle(0.12, 0.46, 0.3, 0.2),
+    );
+  });
+
+  it("aligns a polygon without distorting it", () => {
+    const snapped = snapGeometry(
+      polygon([
+        { x: 0.123, y: 0.2 },
+        { x: 0.323, y: 0.2 },
+        { x: 0.223, y: 0.4 },
+      ]),
+      0.01,
+    );
+    const bounds = boundsOf(snapped);
+    expect(bounds.minX).toBeCloseTo(0.12, 6);
+    expect(bounds.maxX - bounds.minX).toBeCloseTo(0.2, 6);
+  });
+});
+
+describe("bounds", () => {
+  it("bounds a polygon by its extremes", () => {
+    expect(
+      boundsOf(
+        polygon([
+          { x: 0.2, y: 0.3 },
+          { x: 0.8, y: 0.1 },
+          { x: 0.5, y: 0.9 },
+        ]),
+      ),
+    ).toEqual({ minX: 0.2, minY: 0.1, maxX: 0.8, maxY: 0.9 });
+  });
+
+  it("unions several shapes and reports nothing for an empty map", () => {
+    expect(unionBounds([rectangle(0.1, 0.1, 0.2, 0.2), rectangle(0.6, 0.5, 0.2, 0.4)])).toEqual({
+      minX: 0.1,
+      minY: 0.1,
+      maxX: 0.8,
+      maxY: 0.9,
+    });
+    expect(unionBounds([])).toBeNull();
+  });
+});
+
+describe("polygonProblem", () => {
+  const square = [
+    { x: 0.2, y: 0.2 },
+    { x: 0.6, y: 0.2 },
+    { x: 0.6, y: 0.6 },
+    { x: 0.2, y: 0.6 },
+  ];
+
+  it("accepts a simple polygon", () => {
+    expect(polygonProblem(square)).toBeNull();
+  });
+
+  it("rejects a shape whose edges cross", () => {
+    /* Lobes of unequal size, so this fails on the crossing rather than on area. */
+    expect(
+      polygonProblem([
+        { x: 0.1, y: 0.5 },
+        { x: 0.9, y: 0.5 },
+        { x: 0.7, y: 0.1 },
+        { x: 0.2, y: 0.9 },
+      ]),
+    ).toBe("Polygon edges cannot cross.");
+  });
+
+  it("rejects a symmetric bow tie as enclosing nothing", () => {
+    expect(
+      polygonProblem([
+        { x: 0.2, y: 0.2 },
+        { x: 0.6, y: 0.6 },
+        { x: 0.6, y: 0.2 },
+        { x: 0.2, y: 0.6 },
+      ]),
+    ).toBe("The polygon does not enclose an area.");
+  });
+
+  it("rejects too few points, duplicates and zero area", () => {
+    expect(polygonProblem(square.slice(0, 2))).toBe("A polygon needs at least three points.");
+    expect(polygonProblem([...square, { x: 0.2, y: 0.2 }])).toBe("Polygon points must be unique.");
+    expect(
+      polygonProblem([
+        { x: 0.2, y: 0.2 },
+        { x: 0.4, y: 0.2 },
+        { x: 0.6, y: 0.2 },
+      ]),
+    ).toBe("The polygon does not enclose an area.");
+  });
+});
+
+describe("polylinePoints", () => {
+  it("scales normalized points into map units", () => {
+    expect(
+      polylinePoints([
+        { x: 0, y: 0 },
+        { x: 0.5, y: 1 },
+      ]),
+    ).toBe("0,0 50,100");
+  });
+});

--- a/apps/web/src/pages/locations/geometry.ts
+++ b/apps/web/src/pages/locations/geometry.ts
@@ -1,0 +1,239 @@
+import type { MapGeometry } from "@stockcontrol/contracts";
+
+/**
+ * Geometry helpers for the building map, kept free of React so the maths that
+ * decides where a shape lands can be tested directly. Coordinates are the
+ * normalized `[0, 1]` values the API stores; `MAP_UNITS` converts them to the
+ * SVG user space the canvas draws in.
+ */
+
+export interface Point {
+  readonly x: number;
+  readonly y: number;
+}
+
+export type RectangleGeometry = Extract<MapGeometry, { readonly kind: "Rectangle" }>;
+export type PolygonGeometry = Extract<MapGeometry, { readonly kind: "Polygon" }>;
+export type ResizeHandle = "nw" | "ne" | "sw" | "se";
+
+/** Side of the square drawing surface, in SVG user units. */
+export const MAP_UNITS = 100;
+/** Smallest rectangle the server will accept as a meaningful area. */
+export const MIN_REGION_SIZE = 0.02;
+/** Below this, a pointer drag is treated as a click rather than a rectangle. */
+export const MIN_DRAG_SIZE = 0.005;
+/** Grid step used when snapping is on. */
+export const SNAP_STEP = 0.01;
+
+const MAX_POLYGON_POINTS = 128;
+const MIN_AREA = 1e-12;
+
+export const clamp = (value: number): number => Math.max(0, Math.min(1, value));
+
+/** Rounds to the nearest grid step, trimming binary-float noise like 0.30000000000000004. */
+export const snapValue = (value: number, step: number): number =>
+  Number((Math.round(value / step) * step).toFixed(6));
+
+export const snapPoint = (point: Point, step: number): Point => ({
+  x: clamp(snapValue(point.x, step)),
+  y: clamp(snapValue(point.y, step)),
+});
+
+export interface Bounds {
+  readonly minX: number;
+  readonly minY: number;
+  readonly maxX: number;
+  readonly maxY: number;
+}
+
+export const boundsOf = (geometry: MapGeometry): Bounds => {
+  if (geometry.kind === "Rectangle")
+    return {
+      minX: geometry.x,
+      minY: geometry.y,
+      maxX: geometry.x + geometry.width,
+      maxY: geometry.y + geometry.height,
+    };
+  let minX = 1;
+  let minY = 1;
+  let maxX = 0;
+  let maxY = 0;
+  for (const point of geometry.points) {
+    minX = Math.min(minX, point.x);
+    minY = Math.min(minY, point.y);
+    maxX = Math.max(maxX, point.x);
+    maxY = Math.max(maxY, point.y);
+  }
+  return { minX, minY, maxX, maxY };
+};
+
+/** Union of several shapes, or null when there is nothing to bound. */
+export const unionBounds = (geometries: readonly MapGeometry[]): Bounds | null => {
+  if (geometries.length === 0) return null;
+  let bounds: Bounds | null = null;
+  for (const geometry of geometries) {
+    const next = boundsOf(geometry);
+    bounds =
+      bounds === null
+        ? next
+        : {
+            minX: Math.min(bounds.minX, next.minX),
+            minY: Math.min(bounds.minY, next.minY),
+            maxX: Math.max(bounds.maxX, next.maxX),
+            maxY: Math.max(bounds.maxY, next.maxY),
+          };
+  }
+  return bounds;
+};
+
+/** SVG `points` attribute in user units, for polygons and in-progress outlines. */
+export const polylinePoints = (points: readonly Point[]): string =>
+  points.map((point) => `${String(point.x * MAP_UNITS)},${String(point.y * MAP_UNITS)}`).join(" ");
+
+export const moveGeometry = (geometry: MapGeometry, dx: number, dy: number): MapGeometry => {
+  if (geometry.kind === "Rectangle")
+    return {
+      ...geometry,
+      x: Math.min(1 - geometry.width, Math.max(0, geometry.x + dx)),
+      y: Math.min(1 - geometry.height, Math.max(0, geometry.y + dy)),
+    };
+  /*
+   * Polygons move as a body: the delta is limited by the bounding box so the
+   * shape never distorts against the canvas edge.
+   */
+  const bounds = boundsOf(geometry);
+  const boundedX = Math.min(1 - bounds.maxX, Math.max(-bounds.minX, dx));
+  const boundedY = Math.min(1 - bounds.maxY, Math.max(-bounds.minY, dy));
+  return {
+    ...geometry,
+    points: geometry.points.map((point) => ({
+      x: clamp(point.x + boundedX),
+      y: clamp(point.y + boundedY),
+    })),
+  };
+};
+
+/** Aligns a shape's top-left corner to the grid without changing its form. */
+export const snapGeometry = (geometry: MapGeometry, step: number): MapGeometry => {
+  const bounds = boundsOf(geometry);
+  const dx = snapValue(bounds.minX, step) - bounds.minX;
+  const dy = snapValue(bounds.minY, step) - bounds.minY;
+  return dx === 0 && dy === 0 ? geometry : moveGeometry(geometry, dx, dy);
+};
+
+export const resizeRectangle = (
+  geometry: RectangleGeometry,
+  handle: ResizeHandle,
+  point: Point,
+): RectangleGeometry => {
+  const right = geometry.x + geometry.width;
+  const bottom = geometry.y + geometry.height;
+  const movesWest = handle === "nw" || handle === "sw";
+  const movesNorth = handle === "nw" || handle === "ne";
+  const x = clamp(point.x);
+  const y = clamp(point.y);
+  const left = movesWest ? Math.min(x, right - MIN_REGION_SIZE) : geometry.x;
+  const top = movesNorth ? Math.min(y, bottom - MIN_REGION_SIZE) : geometry.y;
+  const nextRight = movesWest ? right : Math.max(x, left + MIN_REGION_SIZE);
+  const nextBottom = movesNorth ? bottom : Math.max(y, top + MIN_REGION_SIZE);
+  return {
+    kind: "Rectangle",
+    x: left,
+    y: top,
+    width: nextRight - left,
+    height: nextBottom - top,
+  };
+};
+
+/**
+ * Builds a rectangle from the two corners of a drag, in any direction. Returns
+ * null when the drag was too small to be anything but a stray click — the old
+ * editor turned those into 2% regions.
+ */
+export const rectangleFromPoints = (start: Point, end: Point): RectangleGeometry | null => {
+  const width = Math.abs(end.x - start.x);
+  const height = Math.abs(end.y - start.y);
+  if (width < MIN_DRAG_SIZE && height < MIN_DRAG_SIZE) return null;
+  const boundedWidth = Math.max(MIN_REGION_SIZE, Math.min(1, width));
+  const boundedHeight = Math.max(MIN_REGION_SIZE, Math.min(1, height));
+  return {
+    kind: "Rectangle",
+    x: Math.max(0, Math.min(Math.min(start.x, end.x), 1 - boundedWidth)),
+    y: Math.max(0, Math.min(Math.min(start.y, end.y), 1 - boundedHeight)),
+    width: boundedWidth,
+    height: boundedHeight,
+  };
+};
+
+const cross = (a: Point, b: Point, c: Point): number =>
+  (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
+
+const onSegment = (a: Point, p: Point, b: Point): boolean =>
+  Math.abs(cross(a, p, b)) <= MIN_AREA &&
+  p.x >= Math.min(a.x, b.x) &&
+  p.x <= Math.max(a.x, b.x) &&
+  p.y >= Math.min(a.y, b.y) &&
+  p.y <= Math.max(a.y, b.y);
+
+const orientation = (a: Point, b: Point, c: Point): -1 | 0 | 1 => {
+  const value = cross(a, b, c);
+  return Math.abs(value) <= MIN_AREA ? 0 : value > 0 ? 1 : -1;
+};
+
+const intersects = (a: Point, b: Point, c: Point, d: Point): boolean => {
+  const abC = orientation(a, b, c);
+  const abD = orientation(a, b, d);
+  const cdA = orientation(c, d, a);
+  const cdB = orientation(c, d, b);
+  if (abC !== abD && cdA !== cdB && abC !== 0 && abD !== 0 && cdA !== 0 && cdB !== 0) return true;
+  return (
+    (abC === 0 && onSegment(a, c, b)) ||
+    (abD === 0 && onSegment(a, d, b)) ||
+    (cdA === 0 && onSegment(c, a, d)) ||
+    (cdB === 0 && onSegment(c, b, d))
+  );
+};
+
+const polygonArea = (points: readonly Point[]): number => {
+  let doubled = 0;
+  for (let index = 0; index < points.length; index += 1) {
+    const current = points[index];
+    const next = points[(index + 1) % points.length];
+    if (current === undefined || next === undefined) continue;
+    doubled += current.x * next.y - next.x * current.y;
+  }
+  return Math.abs(doubled) / 2;
+};
+
+/**
+ * Mirrors the server's polygon rules (`packages/modules/locations`) so a bad
+ * shape is refused while it is being drawn rather than by a 400 on save.
+ * Returns the reason it would be rejected, or null when the shape is valid.
+ */
+export const polygonProblem = (points: readonly Point[]): string | null => {
+  if (points.length < 3) return "A polygon needs at least three points.";
+  if (points.length > MAX_POLYGON_POINTS) return "A polygon can hold at most 128 points.";
+  const keys = points.map((point) => `${String(point.x)}:${String(point.y)}`);
+  if (new Set(keys).size !== points.length) return "Polygon points must be unique.";
+  if (polygonArea(points) <= MIN_AREA) return "The polygon does not enclose an area.";
+  for (let first = 0; first < points.length; first += 1) {
+    const firstNext = (first + 1) % points.length;
+    for (let second = first + 1; second < points.length; second += 1) {
+      const secondNext = (second + 1) % points.length;
+      const adjacent =
+        firstNext === second || secondNext === first || (first === 0 && secondNext === 0);
+      const a = points[first];
+      const b = points[firstNext];
+      const c = points[second];
+      const d = points[secondNext];
+      if (a === undefined || b === undefined || c === undefined || d === undefined) continue;
+      if (!adjacent && intersects(a, b, c, d)) return "Polygon edges cannot cross.";
+    }
+  }
+  return null;
+};
+
+export const geometrySummary = (geometry: MapGeometry): string =>
+  geometry.kind === "Rectangle"
+    ? `Rectangle · ${String(Math.round(geometry.width * 100))}% × ${String(Math.round(geometry.height * 100))}%`
+    : `Polygon · ${String(geometry.points.length)} points`;

--- a/apps/web/src/pages/locations/live-geometry-store.ts
+++ b/apps/web/src/pages/locations/live-geometry-store.ts
@@ -1,0 +1,76 @@
+import type { MapGeometry } from "@stockcontrol/contracts";
+
+import type { Point, RectangleGeometry } from "./geometry";
+
+/**
+ * Holds the geometry of whatever is being dragged, resized or drawn right now.
+ *
+ * This is the reason the editor stays smooth. Pointer moves publish here rather
+ * than dispatching to the reducer, and only the one shape that is moving
+ * subscribes to a non-null value — every other region reads a stable `null`, so
+ * React bails out of re-rendering it. The committed geometry reaches the reducer
+ * once, when the gesture ends.
+ */
+
+export type DrawPreview =
+  | { readonly kind: "rectangle"; readonly geometry: RectangleGeometry }
+  | {
+      readonly kind: "polygon";
+      readonly points: readonly Point[];
+      readonly cursor: Point | null;
+      readonly closeable: boolean;
+    };
+
+export interface LiveGeometryStore {
+  readonly subscribe: (listener: () => void) => () => void;
+  readonly getRegionGeometry: (regionId: string) => MapGeometry | null;
+  readonly getPreview: () => DrawPreview | null;
+  readonly setRegionGeometry: (regionId: string, geometry: MapGeometry) => void;
+  readonly setPreview: (preview: DrawPreview | null) => void;
+  readonly clearRegion: () => void;
+  readonly clear: () => void;
+}
+
+export function createLiveGeometryStore(): LiveGeometryStore {
+  const listeners = new Set<() => void>();
+  let activeRegionId: string | null = null;
+  let activeGeometry: MapGeometry | null = null;
+  let preview: DrawPreview | null = null;
+
+  const emit = (): void => {
+    for (const listener of listeners) listener();
+  };
+
+  return {
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return (): void => {
+        listeners.delete(listener);
+      };
+    },
+    getRegionGeometry: (regionId) => (regionId === activeRegionId ? activeGeometry : null),
+    getPreview: () => preview,
+    setRegionGeometry: (regionId, geometry) => {
+      activeRegionId = regionId;
+      activeGeometry = geometry;
+      emit();
+    },
+    setPreview: (next) => {
+      preview = next;
+      emit();
+    },
+    clearRegion: () => {
+      if (activeRegionId === null && activeGeometry === null) return;
+      activeRegionId = null;
+      activeGeometry = null;
+      emit();
+    },
+    clear: () => {
+      if (activeRegionId === null && activeGeometry === null && preview === null) return;
+      activeRegionId = null;
+      activeGeometry = null;
+      preview = null;
+      emit();
+    },
+  };
+}

--- a/apps/web/src/pages/locations/use-canvas-interaction.ts
+++ b/apps/web/src/pages/locations/use-canvas-interaction.ts
@@ -1,0 +1,612 @@
+import type { MapGeometry, MapRegionView } from "@stockcontrol/contracts";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+
+import type { EditorMode } from "./editor-state";
+import {
+  SNAP_STEP,
+  clamp,
+  moveGeometry,
+  polygonProblem,
+  rectangleFromPoints,
+  resizeRectangle,
+  snapGeometry,
+  snapPoint,
+  type Point,
+  type RectangleGeometry,
+  type ResizeHandle,
+} from "./geometry";
+import type { LiveGeometryStore } from "./live-geometry-store";
+import { useLatestRef } from "./use-latest-ref";
+import type { MapViewportController } from "./use-map-viewport";
+import {
+  distanceBetween,
+  midpointOf,
+  panBy,
+  pinchViewport,
+  screenToNormalized,
+  type PinchStart,
+  type Viewport,
+} from "./viewport";
+
+/** How close, in normalized units, a click must be to close a polygon. */
+const POLYGON_CLOSE_DISTANCE = 0.02;
+/** Arrow-key nudge, and the larger step Shift selects. */
+const NUDGE_STEP = 0.005;
+const NUDGE_STEP_LARGE = 0.02;
+
+type Gesture =
+  | { readonly kind: "idle" }
+  | {
+      readonly kind: "move";
+      readonly pointerId: number;
+      readonly regionId: string;
+      readonly start: Point;
+      readonly origin: MapGeometry;
+    }
+  | {
+      readonly kind: "resize";
+      readonly pointerId: number;
+      readonly regionId: string;
+      readonly handle: ResizeHandle;
+      readonly origin: RectangleGeometry;
+    }
+  | { readonly kind: "draw"; readonly pointerId: number; readonly start: Point }
+  | {
+      readonly kind: "pan";
+      readonly pointerId: number;
+      readonly startClient: Point;
+      readonly startViewport: Viewport;
+    }
+  | { readonly kind: "pinch"; readonly start: PinchStart };
+
+interface PendingPointer {
+  readonly clientX: number;
+  readonly clientY: number;
+  readonly altKey: boolean;
+}
+
+export interface CanvasInteractionOptions {
+  readonly canEdit: boolean;
+  readonly mode: EditorMode;
+  readonly snapEnabled: boolean;
+  readonly regions: readonly MapRegionView[];
+  readonly selectedRegionId: string | null;
+  readonly store: LiveGeometryStore;
+  readonly viewport: MapViewportController;
+  readonly onSelect: (id: string | null) => void;
+  readonly onCommitGeometry: (id: string, geometry: MapGeometry) => void;
+  readonly onCreateRegion: (geometry: MapGeometry) => void;
+  readonly onRemoveRegion: (id: string) => void;
+  readonly onProblem: (message: string) => void;
+}
+
+export interface CanvasInteraction {
+  readonly cursor: string;
+  readonly onPointerDown: (event: ReactPointerEvent<SVGSVGElement>) => void;
+  readonly onPointerMove: (event: ReactPointerEvent<SVGSVGElement>) => void;
+  readonly onPointerUp: (event: ReactPointerEvent<SVGSVGElement>) => void;
+  readonly onPointerCancel: (event: ReactPointerEvent<SVGSVGElement>) => void;
+  readonly onLostPointerCapture: (event: ReactPointerEvent<SVGSVGElement>) => void;
+  readonly onKeyDown: (event: React.KeyboardEvent<SVGSVGElement>) => void;
+  readonly onKeyUp: (event: React.KeyboardEvent<SVGSVGElement>) => void;
+}
+
+const isResizeHandle = (value: string | null): value is ResizeHandle =>
+  value === "nw" || value === "ne" || value === "sw" || value === "se";
+
+/** Preview rectangle for an in-progress drag — no minimum size, so it tracks exactly. */
+const previewRectangle = (start: Point, end: Point): RectangleGeometry => ({
+  kind: "Rectangle",
+  x: Math.min(start.x, end.x),
+  y: Math.min(start.y, end.y),
+  width: Math.max(Math.abs(end.x - start.x), 1e-4),
+  height: Math.max(Math.abs(end.y - start.y), 1e-4),
+});
+
+/**
+ * The pointer and keyboard state machine for the map canvas.
+ *
+ * The important property: nothing here touches React state while a gesture is
+ * running. Pointer moves are gated through one `requestAnimationFrame` and
+ * published to the live-geometry store, which only the shape being dragged
+ * subscribes to. The reducer hears about the change exactly once, on release.
+ * Hit testing is delegated from the `<svg>` root via data attributes, so region
+ * shapes carry no handlers and can be memoised on their data alone.
+ */
+export function useCanvasInteraction(options: CanvasInteractionOptions): CanvasInteraction {
+  const optionsRef = useLatestRef(options);
+  const gestureRef = useRef<Gesture>({ kind: "idle" });
+  const pendingRef = useRef<PendingPointer | null>(null);
+  const frameRef = useRef<number | null>(null);
+  const movedRef = useRef(false);
+  const liveGeometryRef = useRef<MapGeometry | null>(null);
+  const drawEndRef = useRef<Point | null>(null);
+  const gestureStartClientRef = useRef<Point>({ x: 0, y: 0 });
+  const polygonRef = useRef<readonly Point[]>([]);
+  const pointersRef = useRef(new Map<number, Point>());
+
+  const regionsById = useMemo(
+    () => new Map(options.regions.map((region) => [region.id, region])),
+    [options.regions],
+  );
+  const regionsRef = useLatestRef(regionsById);
+
+  const normalizedFrom = useCallback(
+    (clientX: number, clientY: number): Point => {
+      const { rectRef, viewport } = optionsRef.current.viewport;
+      const rect = rectRef.current;
+      const point = screenToNormalized(viewport, {
+        x: clientX - rect.left,
+        y: clientY - rect.top,
+      });
+      return { x: clamp(point.x), y: clamp(point.y) };
+    },
+    [optionsRef],
+  );
+
+  const snapped = useCallback(
+    (point: Point, altKey: boolean): Point => {
+      /* Alt is the escape hatch from the grid, the way most editors do it. */
+      return optionsRef.current.snapEnabled && !altKey ? snapPoint(point, SNAP_STEP) : point;
+    },
+    [optionsRef],
+  );
+
+  const publishPolygonPreview = useCallback(
+    (cursor: Point | null): void => {
+      const points = polygonRef.current;
+      if (points.length === 0) {
+        optionsRef.current.store.setPreview(null);
+        return;
+      }
+      const first = points[0];
+      optionsRef.current.store.setPreview({
+        kind: "polygon",
+        points,
+        cursor,
+        closeable:
+          points.length >= 3 &&
+          cursor !== null &&
+          first !== undefined &&
+          distanceBetween(first, cursor) <= POLYGON_CLOSE_DISTANCE,
+      });
+    },
+    [optionsRef],
+  );
+
+  const flush = useCallback((): void => {
+    frameRef.current = null;
+    const pending = pendingRef.current;
+    const gesture = gestureRef.current;
+    if (pending === null) return;
+    const { store, viewport } = optionsRef.current;
+
+    if (gesture.kind === "pan") {
+      viewport.applyViewport(
+        panBy(
+          gesture.startViewport,
+          pending.clientX - gesture.startClient.x,
+          pending.clientY - gesture.startClient.y,
+        ),
+      );
+      return;
+    }
+    if (gesture.kind === "pinch") {
+      const [first, second] = [...pointersRef.current.values()];
+      if (first === undefined || second === undefined) return;
+      viewport.applyViewport(
+        pinchViewport(
+          gesture.start,
+          { midpoint: midpointOf(first, second), distance: distanceBetween(first, second) },
+          viewport.fitScale,
+        ),
+      );
+      return;
+    }
+
+    const point = normalizedFrom(pending.clientX, pending.clientY);
+    /* A click that selects a region must not mark the map dirty. */
+    const dragged =
+      Math.hypot(
+        pending.clientX - gestureStartClientRef.current.x,
+        pending.clientY - gestureStartClientRef.current.y,
+      ) > 2;
+
+    if (gesture.kind === "move") {
+      if (!dragged) return;
+      const moved = moveGeometry(
+        gesture.origin,
+        point.x - gesture.start.x,
+        point.y - gesture.start.y,
+      );
+      const geometry =
+        optionsRef.current.snapEnabled && !pending.altKey ? snapGeometry(moved, SNAP_STEP) : moved;
+      liveGeometryRef.current = geometry;
+      movedRef.current = true;
+      store.setRegionGeometry(gesture.regionId, geometry);
+      return;
+    }
+    if (gesture.kind === "resize") {
+      if (!dragged) return;
+      const geometry = resizeRectangle(
+        gesture.origin,
+        gesture.handle,
+        snapped(point, pending.altKey),
+      );
+      liveGeometryRef.current = geometry;
+      movedRef.current = true;
+      store.setRegionGeometry(gesture.regionId, geometry);
+      return;
+    }
+    if (gesture.kind === "draw") {
+      const end = snapped(point, pending.altKey);
+      drawEndRef.current = end;
+      store.setPreview({ kind: "rectangle", geometry: previewRectangle(gesture.start, end) });
+      return;
+    }
+    if (optionsRef.current.mode === "polygon")
+      publishPolygonPreview(snapped(point, pending.altKey));
+  }, [normalizedFrom, optionsRef, publishPolygonPreview, snapped]);
+
+  const schedule = useCallback(
+    (event: ReactPointerEvent<SVGSVGElement>): void => {
+      pendingRef.current = {
+        clientX: event.clientX,
+        clientY: event.clientY,
+        altKey: event.altKey,
+      };
+      /*
+       * One frame per paint, however fast the pointer reports. This gate is what
+       * turns ~120 state updates a second into at most 60 renders of a single
+       * memoised shape.
+       */
+      frameRef.current ??= requestAnimationFrame(flush);
+    },
+    [flush],
+  );
+
+  const cancelFrame = useCallback((): void => {
+    if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+    frameRef.current = null;
+    pendingRef.current = null;
+  }, []);
+
+  const endGesture = useCallback(
+    (commit: boolean): void => {
+      const gesture = gestureRef.current;
+      const geometry = liveGeometryRef.current;
+      const end = drawEndRef.current;
+      const { store, onCommitGeometry, onCreateRegion } = optionsRef.current;
+      cancelFrame();
+      gestureRef.current = { kind: "idle" };
+      liveGeometryRef.current = null;
+      drawEndRef.current = null;
+
+      if ((gesture.kind === "move" || gesture.kind === "resize") && geometry !== null) {
+        /* One dispatch for the whole gesture, however many frames it took. */
+        if (commit && movedRef.current) onCommitGeometry(gesture.regionId, geometry);
+        store.clearRegion();
+      }
+      if (gesture.kind === "draw") {
+        const rectangle = end === null ? null : rectangleFromPoints(gesture.start, end);
+        store.setPreview(null);
+        if (commit && rectangle !== null) onCreateRegion(rectangle);
+      }
+      movedRef.current = false;
+    },
+    [cancelFrame, optionsRef],
+  );
+
+  const finishPolygon = useCallback((): void => {
+    const points = polygonRef.current;
+    const { onCreateRegion, onProblem, store } = optionsRef.current;
+    if (points.length < 3) return;
+    const problem = polygonProblem(points);
+    if (problem !== null) {
+      onProblem(problem);
+      return;
+    }
+    polygonRef.current = [];
+    store.setPreview(null);
+    onCreateRegion({ kind: "Polygon", points });
+  }, [optionsRef]);
+
+  const cancelPolygon = useCallback((): void => {
+    polygonRef.current = [];
+    optionsRef.current.store.setPreview(null);
+  }, [optionsRef]);
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<SVGSVGElement>): void => {
+      const { canEdit, mode, viewport, onSelect } = optionsRef.current;
+      if (event.button !== 0 && event.button !== 1) return;
+      const rect = viewport.refreshRect();
+      const client = { x: event.clientX, y: event.clientY };
+      gestureStartClientRef.current = client;
+      pointersRef.current.set(event.pointerId, {
+        x: client.x - rect.left,
+        y: client.y - rect.top,
+      });
+      event.currentTarget.setPointerCapture(event.pointerId);
+
+      /* A second touch turns whatever was happening into a pinch. */
+      if (pointersRef.current.size === 2 && event.pointerType === "touch") {
+        const [first, second] = [...pointersRef.current.values()];
+        if (first !== undefined && second !== undefined) {
+          endGesture(false);
+          gestureRef.current = {
+            kind: "pinch",
+            start: {
+              viewport: viewport.viewport,
+              midpoint: midpointOf(first, second),
+              distance: distanceBetween(first, second),
+            },
+          };
+        }
+        return;
+      }
+
+      const panning = event.button === 1 || viewport.spaceHeld || mode === "pan";
+      if (panning) {
+        gestureRef.current = {
+          kind: "pan",
+          pointerId: event.pointerId,
+          startClient: client,
+          startViewport: viewport.viewport,
+        };
+        return;
+      }
+
+      const point = normalizedFrom(event.clientX, event.clientY);
+
+      if (canEdit && mode === "polygon") {
+        const next = snapped(point, event.altKey);
+        const first = polygonRef.current[0];
+        if (
+          polygonRef.current.length >= 3 &&
+          first !== undefined &&
+          distanceBetween(first, next) <= POLYGON_CLOSE_DISTANCE
+        ) {
+          finishPolygon();
+          return;
+        }
+        polygonRef.current = [...polygonRef.current, next];
+        publishPolygonPreview(next);
+        return;
+      }
+
+      if (canEdit && mode === "rectangle") {
+        gestureRef.current = {
+          kind: "draw",
+          pointerId: event.pointerId,
+          start: snapped(point, event.altKey),
+        };
+        return;
+      }
+
+      const target = event.target as Element;
+      const handleElement = target.closest("[data-handle]");
+      const handle = handleElement?.getAttribute("data-handle") ?? null;
+      const regionId =
+        target.closest("[data-region-id]")?.getAttribute("data-region-id") ??
+        handleElement?.getAttribute("data-handle-region") ??
+        null;
+
+      if (regionId === null) {
+        onSelect(null);
+        return;
+      }
+      const region = regionsRef.current.get(regionId);
+      if (region === undefined) return;
+      onSelect(regionId);
+      if (!canEdit || region.status === "Archived") return;
+
+      if (isResizeHandle(handle) && region.geometry.kind === "Rectangle") {
+        gestureRef.current = {
+          kind: "resize",
+          pointerId: event.pointerId,
+          regionId,
+          handle,
+          origin: region.geometry,
+        };
+        return;
+      }
+      gestureRef.current = {
+        kind: "move",
+        pointerId: event.pointerId,
+        regionId,
+        start: point,
+        origin: region.geometry,
+      };
+    },
+    [
+      endGesture,
+      finishPolygon,
+      normalizedFrom,
+      optionsRef,
+      publishPolygonPreview,
+      regionsRef,
+      snapped,
+    ],
+  );
+
+  const onPointerMove = useCallback(
+    (event: ReactPointerEvent<SVGSVGElement>): void => {
+      const rect = optionsRef.current.viewport.rectRef.current;
+      if (pointersRef.current.has(event.pointerId))
+        pointersRef.current.set(event.pointerId, {
+          x: event.clientX - rect.left,
+          y: event.clientY - rect.top,
+        });
+      /* Idle and not mid-polygon means there is nothing to recompute. */
+      if (gestureRef.current.kind === "idle" && polygonRef.current.length === 0) return;
+      schedule(event);
+    },
+    [optionsRef, schedule],
+  );
+
+  const releasePointer = useCallback(
+    (event: ReactPointerEvent<SVGSVGElement>, commit: boolean): void => {
+      pointersRef.current.delete(event.pointerId);
+      if (gestureRef.current.kind === "idle") return;
+      if (gestureRef.current.kind === "pinch" && pointersRef.current.size > 0) return;
+      cancelFrame();
+      if (commit) {
+        /* Settle on the release position rather than the last painted frame. */
+        pendingRef.current = {
+          clientX: event.clientX,
+          clientY: event.clientY,
+          altKey: event.altKey,
+        };
+        flush();
+      }
+      endGesture(commit);
+    },
+    [cancelFrame, endGesture, flush],
+  );
+
+  const onPointerUp = useCallback(
+    (event: ReactPointerEvent<SVGSVGElement>): void => {
+      releasePointer(event, true);
+    },
+    [releasePointer],
+  );
+
+  const onPointerCancel = useCallback(
+    (event: ReactPointerEvent<SVGSVGElement>): void => {
+      releasePointer(event, false);
+    },
+    [releasePointer],
+  );
+
+  const onLostPointerCapture = useCallback(
+    (event: ReactPointerEvent<SVGSVGElement>): void => {
+      /*
+       * Without this the old editor left its drag record set when the pointer
+       * went away, and the region resumed moving on the next unrelated event.
+       */
+      releasePointer(event, true);
+    },
+    [releasePointer],
+  );
+
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent<SVGSVGElement>): void => {
+      const {
+        canEdit,
+        mode,
+        regions,
+        selectedRegionId,
+        onSelect,
+        onCommitGeometry,
+        onRemoveRegion,
+        viewport,
+      } = optionsRef.current;
+      if (viewport.handleKey(event)) {
+        event.preventDefault();
+        return;
+      }
+
+      if (mode === "polygon" && polygonRef.current.length > 0) {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          finishPolygon();
+          return;
+        }
+        if (event.key === "Escape") {
+          event.preventDefault();
+          cancelPolygon();
+          return;
+        }
+        if (event.key === "Backspace") {
+          event.preventDefault();
+          polygonRef.current = polygonRef.current.slice(0, -1);
+          publishPolygonPreview(null);
+          return;
+        }
+      }
+
+      if (event.key === "Escape") {
+        onSelect(null);
+        return;
+      }
+      if (event.key === "Enter" && selectedRegionId === null && regions.length > 0) {
+        event.preventDefault();
+        onSelect(regions[0]?.id ?? null);
+        return;
+      }
+
+      const selected =
+        selectedRegionId === null ? undefined : regionsRef.current.get(selectedRegionId);
+
+      /* Tab walks the regions while one is selected, instead of every shape being a tab stop. */
+      if (event.key === "Tab" && selected !== undefined && regions.length > 1) {
+        event.preventDefault();
+        const index = regions.findIndex((region) => region.id === selected.id);
+        const next = (index + (event.shiftKey ? -1 : 1) + regions.length) % regions.length;
+        onSelect(regions[next]?.id ?? null);
+        return;
+      }
+
+      if (!canEdit || selected === undefined) return;
+
+      if (event.key === "Delete" || event.key === "Backspace") {
+        event.preventDefault();
+        onRemoveRegion(selected.id);
+        return;
+      }
+
+      const step = event.shiftKey ? NUDGE_STEP_LARGE : NUDGE_STEP;
+      const dx = event.key === "ArrowLeft" ? -step : event.key === "ArrowRight" ? step : 0;
+      const dy = event.key === "ArrowUp" ? -step : event.key === "ArrowDown" ? step : 0;
+      if (dx === 0 && dy === 0) return;
+      event.preventDefault();
+      onCommitGeometry(selected.id, moveGeometry(selected.geometry, dx, dy));
+    },
+    [cancelPolygon, finishPolygon, optionsRef, publishPolygonPreview, regionsRef],
+  );
+
+  const onKeyUp = useCallback(
+    (event: React.KeyboardEvent<SVGSVGElement>): void => {
+      optionsRef.current.viewport.handleKey(event);
+    },
+    [optionsRef],
+  );
+
+  /* Leaving the tool or the page mid-draw should not strand a preview on screen. */
+  useEffect(() => {
+    if (options.mode === "polygon") return;
+    polygonRef.current = [];
+    options.store.setPreview(null);
+  }, [options.mode, options.store]);
+
+  useEffect(() => {
+    const store = options.store;
+    return (): void => {
+      store.clear();
+    };
+  }, [options.store]);
+
+  const cursor = useMemo(() => {
+    if (options.viewport.spaceHeld || options.mode === "pan") return "grab";
+    if (options.mode === "rectangle" || options.mode === "polygon") return "crosshair";
+    return "default";
+  }, [options.mode, options.viewport.spaceHeld]);
+
+  return {
+    cursor,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
+    onLostPointerCapture,
+    onKeyDown,
+    onKeyUp,
+  };
+}

--- a/apps/web/src/pages/locations/use-latest-ref.ts
+++ b/apps/web/src/pages/locations/use-latest-ref.ts
@@ -1,0 +1,17 @@
+import { useLayoutEffect, useRef, type RefObject } from "react";
+
+/**
+ * Keeps the newest value reachable from a callback that must not change
+ * identity. Pointer handlers are registered once per gesture and read plenty of
+ * state; rebuilding them on every render would defeat the memo boundaries that
+ * keep dragging cheap.
+ */
+export function useLatestRef<Value>(value: Value): RefObject<Value> {
+  const ref = useRef(value);
+
+  useLayoutEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref;
+}

--- a/apps/web/src/pages/locations/use-map-viewport.ts
+++ b/apps/web/src/pages/locations/use-map-viewport.ts
@@ -1,0 +1,233 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
+
+import type { Point } from "./geometry";
+import { useLatestRef } from "./use-latest-ref";
+import {
+  ZOOM_STEP,
+  clampScale,
+  clampViewport,
+  fitScaleFor,
+  fitViewport,
+  identityViewport,
+  panBy,
+  zoomAt,
+  zoomPercent,
+  type Size,
+  type Viewport,
+} from "./viewport";
+
+export interface MapViewportController {
+  readonly viewport: Viewport;
+  readonly size: Size;
+  readonly fitScale: number;
+  readonly zoomPercentage: number;
+  readonly spaceHeld: boolean;
+  /**
+   * Callback ref. The canvas only mounts once a map has loaded, so a plain ref
+   * would still be null when the observer effect ran and the viewport would
+   * never be measured.
+   */
+  readonly attachContainer: (element: HTMLDivElement | null) => void;
+  /** Canvas box, measured once per gesture rather than once per pointer move. */
+  readonly rectRef: RefObject<DOMRect>;
+  readonly refreshRect: () => DOMRect;
+  readonly applyViewport: (next: Viewport) => void;
+  readonly zoomByStep: (steps: number) => void;
+  readonly zoomToPoint: (anchor: Point, nextScale: number) => void;
+  readonly fit: () => void;
+  /** Returns true when the key was a viewport shortcut and has been handled. */
+  readonly handleKey: (event: React.KeyboardEvent) => boolean;
+}
+
+const emptyRect = (): DOMRect => ({
+  x: 0,
+  y: 0,
+  left: 0,
+  top: 0,
+  right: 0,
+  bottom: 0,
+  width: 0,
+  height: 0,
+  toJSON: () => ({}),
+});
+
+/**
+ * Owns pan and zoom for the map canvas.
+ *
+ * The transform lives here rather than on the `<svg>` as a CSS `scale()`: the
+ * old approach zoomed about the element centre inside an `overflow: hidden` box,
+ * so magnified content was clipped and unreachable, and the Pan tool had nothing
+ * to drive at all.
+ */
+export function useMapViewport(): MapViewportController {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+  const rectRef = useRef<DOMRect>(emptyRect());
+  const [size, setSize] = useState<Size>({ width: 0, height: 0 });
+  const [viewport, setViewport] = useState<Viewport>(identityViewport);
+  const [spaceHeld, setSpaceHeld] = useState(false);
+  /* Until the user pans or zooms, a resize refits rather than stranding the map. */
+  const adjustedRef = useRef(false);
+  const sizeRef = useLatestRef(size);
+  const viewportRef = useLatestRef(viewport);
+
+  const fitScale = useMemo(() => fitScaleFor(size), [size]);
+
+  const attachContainer = useCallback((element: HTMLDivElement | null): void => {
+    containerRef.current = element;
+    setContainer(element);
+  }, []);
+
+  const refreshRect = useCallback((): DOMRect => {
+    const element = containerRef.current;
+    if (element !== null) rectRef.current = element.getBoundingClientRect();
+    return rectRef.current;
+  }, []);
+
+  /* Falls back to the measured box if a gesture beats the first size update. */
+  const currentSize = useCallback((): Size => {
+    const known = sizeRef.current;
+    if (known.width > 0 && known.height > 0) return known;
+    const rect = rectRef.current;
+    return { width: rect.width, height: rect.height };
+  }, [sizeRef]);
+
+  const applyViewport = useCallback(
+    (next: Viewport): void => {
+      adjustedRef.current = true;
+      setViewport(clampViewport(next, currentSize()));
+    },
+    [currentSize],
+  );
+
+  const fit = useCallback((): void => {
+    adjustedRef.current = false;
+    setViewport(fitViewport(currentSize()));
+  }, [currentSize]);
+
+  const zoomToPoint = useCallback(
+    (anchor: Point, nextScale: number): void => {
+      applyViewport(
+        zoomAt(viewportRef.current, anchor, clampScale(nextScale, fitScaleFor(currentSize()))),
+      );
+    },
+    [applyViewport, currentSize, viewportRef],
+  );
+
+  const zoomByStep = useCallback(
+    (steps: number): void => {
+      const size = currentSize();
+      zoomToPoint(
+        { x: size.width / 2, y: size.height / 2 },
+        viewportRef.current.scale * ZOOM_STEP ** steps,
+      );
+    },
+    [currentSize, viewportRef, zoomToPoint],
+  );
+
+  /* Measure the canvas, and keep the map framed while the user has not moved it. */
+  useEffect(() => {
+    const element = container;
+    if (element === null) return;
+
+    const measure = (): void => {
+      const rect = element.getBoundingClientRect();
+      rectRef.current = rect;
+      const next = { width: rect.width, height: rect.height };
+      setSize((current) =>
+        current.width === next.width && current.height === next.height ? current : next,
+      );
+      setViewport((current) =>
+        adjustedRef.current ? clampViewport(current, next) : fitViewport(next),
+      );
+    };
+
+    /* Take the first measurement rather than waiting on the observer's own. */
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return (): void => {
+      observer.disconnect();
+    };
+  }, [container]);
+
+  /*
+   * React registers wheel listeners passively, so preventDefault() from an
+   * onWheel prop is ignored and the page scrolls underneath the map. The
+   * listener has to be attached by hand.
+   */
+  useEffect(() => {
+    const element = container;
+    if (element === null) return;
+
+    const onWheel = (event: WheelEvent): void => {
+      event.preventDefault();
+      const rect = rectRef.current.width === 0 ? refreshRect() : rectRef.current;
+      if (event.ctrlKey || event.metaKey) {
+        const anchor = { x: event.clientX - rect.left, y: event.clientY - rect.top };
+        zoomToPoint(anchor, viewportRef.current.scale * Math.exp(-event.deltaY / 100));
+        return;
+      }
+      const horizontal = event.shiftKey ? event.deltaY : event.deltaX;
+      const vertical = event.shiftKey ? event.deltaX : event.deltaY;
+      applyViewport(panBy(viewportRef.current, -horizontal, -vertical));
+    };
+
+    element.addEventListener("wheel", onWheel, { passive: false });
+    return (): void => {
+      element.removeEventListener("wheel", onWheel);
+    };
+  }, [applyViewport, container, refreshRect, viewportRef, zoomToPoint]);
+
+  /* A blur while space is held would otherwise leave the canvas stuck in pan mode. */
+  useEffect(() => {
+    if (!spaceHeld) return;
+    const release = (): void => {
+      setSpaceHeld(false);
+    };
+    window.addEventListener("blur", release);
+    return (): void => {
+      window.removeEventListener("blur", release);
+    };
+  }, [spaceHeld]);
+
+  const handleKey = useCallback(
+    (event: React.KeyboardEvent): boolean => {
+      if (event.key === " ") {
+        setSpaceHeld(event.type === "keydown");
+        return true;
+      }
+      if (event.type !== "keydown") return false;
+      if (event.key === "+" || event.key === "=") {
+        zoomByStep(1);
+        return true;
+      }
+      if (event.key === "-" || event.key === "_") {
+        zoomByStep(-1);
+        return true;
+      }
+      if (event.key === "0") {
+        fit();
+        return true;
+      }
+      return false;
+    },
+    [fit, zoomByStep],
+  );
+
+  return {
+    viewport,
+    size,
+    fitScale,
+    zoomPercentage: zoomPercent(viewport, fitScale),
+    spaceHeld,
+    attachContainer,
+    rectRef,
+    refreshRect,
+    applyViewport,
+    zoomByStep,
+    zoomToPoint,
+    fit,
+    handleKey,
+  };
+}

--- a/apps/web/src/pages/locations/viewport.test.ts
+++ b/apps/web/src/pages/locations/viewport.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+
+import { MAP_UNITS } from "./geometry";
+import {
+  FIT_PADDING,
+  MAX_SCALE_FACTOR,
+  MIN_SCALE_FACTOR,
+  clampScale,
+  clampViewport,
+  clientToOffset,
+  distanceBetween,
+  fitScaleFor,
+  fitViewport,
+  mapToScreen,
+  midpointOf,
+  panBy,
+  pinchViewport,
+  screenToMap,
+  screenToNormalized,
+  transformAttribute,
+  zoomAt,
+  zoomPercent,
+  type Viewport,
+} from "./viewport";
+
+const wide = { width: 800, height: 600 };
+const square = { width: 600, height: 600 };
+
+describe("fitViewport", () => {
+  it("reproduces the letterboxed fit the old canvas rendered", () => {
+    /*
+     * The previous canvas used viewBox="0 0 100 100" with the default
+     * preserveAspectRatio, which centres a square of side min(w, h). Matching it
+     * means nothing moves visually at 100%.
+     */
+    const viewport = fitViewport(wide);
+    const side = MAP_UNITS * viewport.scale;
+
+    expect(side).toBeCloseTo(Math.min(wide.width, wide.height) - FIT_PADDING * 2, 9);
+    expect(viewport.offsetX).toBeCloseTo((wide.width - side) / 2, 9);
+    expect(viewport.offsetY).toBeCloseTo((wide.height - side) / 2, 9);
+  });
+
+  it("centres on a square canvas too", () => {
+    const viewport = fitViewport(square);
+    expect(viewport.offsetX).toBeCloseTo(viewport.offsetY, 9);
+  });
+
+  it("survives a canvas that has not been measured yet", () => {
+    expect(fitScaleFor({ width: 0, height: 0 })).toBeGreaterThan(0);
+  });
+});
+
+describe("screen and map coordinates", () => {
+  const viewport = fitViewport(wide);
+
+  it("round-trips through map units", () => {
+    for (const point of [
+      { x: 0, y: 0 },
+      { x: 50, y: 50 },
+      { x: 100, y: 12.5 },
+    ]) {
+      const back = screenToMap(viewport, mapToScreen(viewport, point));
+      expect(back.x).toBeCloseTo(point.x, 9);
+      expect(back.y).toBeCloseTo(point.y, 9);
+    }
+  });
+
+  it("puts the centre of a non-square canvas at the centre of the map", () => {
+    /*
+     * The bug this replaces: the old code divided by the element's width and
+     * height, so on an 800x600 canvas the centre mapped to (0.5, 0.5) only by
+     * accident and every other point was skewed.
+     */
+    const centre = screenToNormalized(viewport, { x: wide.width / 2, y: wide.height / 2 });
+    expect(centre.x).toBeCloseTo(0.5, 9);
+    expect(centre.y).toBeCloseTo(0.5, 9);
+  });
+
+  it("maps the map's own corners to its rendered box, not the element box", () => {
+    const topLeft = mapToScreen(viewport, { x: 0, y: 0 });
+    expect(topLeft.x).toBeCloseTo(FIT_PADDING + 100, 9);
+    expect(topLeft.y).toBeCloseTo(FIT_PADDING, 9);
+  });
+
+  it("subtracts the canvas position from client coordinates", () => {
+    const rect = { left: 40, top: 20 } as DOMRectReadOnly;
+    expect(clientToOffset(rect, 140, 120)).toEqual({ x: 100, y: 100 });
+  });
+});
+
+describe("zoomAt", () => {
+  const viewport = fitViewport(wide);
+
+  it("holds the point under the cursor still", () => {
+    const anchor = { x: 220, y: 380 };
+    const before = screenToMap(viewport, anchor);
+    const after = screenToMap(zoomAt(viewport, anchor, viewport.scale * 2.5), anchor);
+
+    expect(after.x).toBeCloseTo(before.x, 9);
+    expect(after.y).toBeCloseTo(before.y, 9);
+  });
+
+  it("returns to where it started after zooming in and back out", () => {
+    const anchor = { x: 610, y: 90 };
+    const zoomed = zoomAt(viewport, anchor, viewport.scale * 3);
+    const restored = zoomAt(zoomed, anchor, viewport.scale);
+
+    expect(restored.scale).toBeCloseTo(viewport.scale, 9);
+    expect(restored.offsetX).toBeCloseTo(viewport.offsetX, 9);
+    expect(restored.offsetY).toBeCloseTo(viewport.offsetY, 9);
+  });
+});
+
+describe("clampScale", () => {
+  it("bounds zoom to a multiple of the fitted scale", () => {
+    const fit = fitScaleFor(wide);
+    expect(clampScale(fit * 100, fit)).toBeCloseTo(fit * MAX_SCALE_FACTOR, 9);
+    expect(clampScale(fit / 100, fit)).toBeCloseTo(fit * MIN_SCALE_FACTOR, 9);
+    expect(clampScale(fit * 2, fit)).toBeCloseTo(fit * 2, 9);
+  });
+});
+
+describe("panBy and clampViewport", () => {
+  const viewport = fitViewport(wide);
+
+  it("translates without touching the scale", () => {
+    const panned = panBy(viewport, 30, -20);
+    expect(panned.scale).toBe(viewport.scale);
+    expect(panned.offsetX).toBeCloseTo(viewport.offsetX + 30, 9);
+    expect(panned.offsetY).toBeCloseTo(viewport.offsetY - 20, 9);
+  });
+
+  it("never lets the map be pushed entirely off the canvas", () => {
+    const lost = clampViewport(panBy(viewport, 100_000, 100_000), wide);
+    const span = MAP_UNITS * viewport.scale;
+
+    expect(lost.offsetX).toBeLessThan(wide.width);
+    expect(lost.offsetX + span).toBeGreaterThan(0);
+    expect(lost.offsetY + span).toBeGreaterThan(0);
+  });
+
+  it("leaves a viewport that is already on screen alone", () => {
+    expect(clampViewport(viewport, wide)).toEqual(viewport);
+  });
+});
+
+describe("pinchViewport", () => {
+  const viewport = fitViewport(wide);
+
+  it("scales by the change in finger distance and follows the midpoint", () => {
+    const start = {
+      viewport,
+      midpoint: midpointOf({ x: 300, y: 300 }, { x: 400, y: 300 }),
+      distance: distanceBetween({ x: 300, y: 300 }, { x: 400, y: 300 }),
+    };
+    const pinched = pinchViewport(
+      start,
+      {
+        midpoint: midpointOf({ x: 300, y: 300 }, { x: 500, y: 300 }),
+        distance: distanceBetween({ x: 300, y: 300 }, { x: 500, y: 300 }),
+      },
+      fitScaleFor(wide),
+    );
+
+    expect(pinched.scale).toBeCloseTo(viewport.scale * 2, 9);
+  });
+
+  it("does nothing useful but stays finite when the fingers start together", () => {
+    const degenerate = pinchViewport(
+      { viewport, midpoint: { x: 10, y: 10 }, distance: 0 },
+      { midpoint: { x: 10, y: 10 }, distance: 50 },
+      fitScaleFor(wide),
+    );
+    expect(Number.isFinite(degenerate.scale)).toBe(true);
+  });
+});
+
+describe("presentation", () => {
+  it("writes an SVG transform", () => {
+    const viewport: Viewport = { scale: 2, offsetX: 10, offsetY: -5 };
+    expect(transformAttribute(viewport)).toBe("translate(10 -5) scale(2)");
+  });
+
+  it("reports 100% when the map fits the canvas", () => {
+    const viewport = fitViewport(wide);
+    expect(zoomPercent(viewport, fitScaleFor(wide))).toBe(100);
+    expect(zoomPercent({ ...viewport, scale: viewport.scale * 2 }, fitScaleFor(wide))).toBe(200);
+  });
+});

--- a/apps/web/src/pages/locations/viewport.ts
+++ b/apps/web/src/pages/locations/viewport.ts
@@ -1,0 +1,154 @@
+import { MAP_UNITS, type Point } from "./geometry";
+
+/**
+ * The map's pan-and-zoom transform.
+ *
+ * The canvas deliberately has no `viewBox`: SVG user units are CSS pixels with
+ * the origin at the element's top-left, and everything drawn sits inside one
+ * group carrying `translate(offsetX offsetY) scale(scale)`. That keeps a single
+ * affine under our control — the previous `viewBox` plus `preserveAspectRatio`
+ * letterboxed the coordinate system, so pointer maths that measured the element
+ * box put shapes somewhere other than the cursor.
+ *
+ * `scale` maps the 0–100 map-unit square to pixels; `offsetX`/`offsetY` are the
+ * pixel position of the map's top-left corner within the canvas.
+ */
+export interface Viewport {
+  readonly scale: number;
+  readonly offsetX: number;
+  readonly offsetY: number;
+}
+
+export interface Size {
+  readonly width: number;
+  readonly height: number;
+}
+
+/** Zoom range, expressed as multiples of the scale that fits the canvas. */
+export const MIN_SCALE_FACTOR = 0.5;
+export const MAX_SCALE_FACTOR = 8;
+/** Ratio applied by the toolbar's zoom buttons and the +/- keys. */
+export const ZOOM_STEP = 1.25;
+/** Breathing room left around the map when fitting. */
+export const FIT_PADDING = 8;
+/** Panning always leaves at least this much of the map on screen. */
+const MIN_VISIBLE_PIXELS = 48;
+
+export const identityViewport: Viewport = { scale: 1, offsetX: 0, offsetY: 0 };
+
+/**
+ * The scale at which the map exactly fits the canvas — the same result the old
+ * `preserveAspectRatio="xMidYMid meet"` produced, so nothing moves visually at
+ * 100%.
+ */
+export const fitScaleFor = (size: Size, padding: number = FIT_PADDING): number => {
+  const usableWidth = Math.max(1, size.width - padding * 2);
+  const usableHeight = Math.max(1, size.height - padding * 2);
+  return Math.max(Number.EPSILON, Math.min(usableWidth, usableHeight) / MAP_UNITS);
+};
+
+export const fitViewport = (size: Size, padding: number = FIT_PADDING): Viewport => {
+  const scale = fitScaleFor(size, padding);
+  return {
+    scale,
+    offsetX: (size.width - MAP_UNITS * scale) / 2,
+    offsetY: (size.height - MAP_UNITS * scale) / 2,
+  };
+};
+
+export const clampScale = (scale: number, fitScale: number): number =>
+  Math.min(Math.max(scale, fitScale * MIN_SCALE_FACTOR), fitScale * MAX_SCALE_FACTOR);
+
+/** Canvas-relative pixels to map units (0–100). */
+export const screenToMap = (viewport: Viewport, offset: Point): Point => ({
+  x: (offset.x - viewport.offsetX) / viewport.scale,
+  y: (offset.y - viewport.offsetY) / viewport.scale,
+});
+
+/** Map units back to canvas-relative pixels. */
+export const mapToScreen = (viewport: Viewport, point: Point): Point => ({
+  x: point.x * viewport.scale + viewport.offsetX,
+  y: point.y * viewport.scale + viewport.offsetY,
+});
+
+/** Canvas-relative pixels to the normalized `[0, 1]` values the API stores. */
+export const screenToNormalized = (viewport: Viewport, offset: Point): Point => {
+  const point = screenToMap(viewport, offset);
+  return { x: point.x / MAP_UNITS, y: point.y / MAP_UNITS };
+};
+
+/** Converts a client (viewport) coordinate into a canvas-relative one. */
+export const clientToOffset = (rect: DOMRectReadOnly, clientX: number, clientY: number): Point => ({
+  x: clientX - rect.left,
+  y: clientY - rect.top,
+});
+
+export const panBy = (viewport: Viewport, dx: number, dy: number): Viewport => ({
+  ...viewport,
+  offsetX: viewport.offsetX + dx,
+  offsetY: viewport.offsetY + dy,
+});
+
+/**
+ * Rescales while holding the map point under `anchor` still: from
+ * `anchor = map * scale + offset` it follows that
+ * `offset' = anchor - (anchor - offset) * (scale' / scale)`.
+ */
+export const zoomAt = (viewport: Viewport, anchor: Point, nextScale: number): Viewport => {
+  const ratio = nextScale / viewport.scale;
+  return {
+    scale: nextScale,
+    offsetX: anchor.x - (anchor.x - viewport.offsetX) * ratio,
+    offsetY: anchor.y - (anchor.y - viewport.offsetY) * ratio,
+  };
+};
+
+/** Keeps the map reachable: it can never be dragged entirely off the canvas. */
+export const clampViewport = (viewport: Viewport, size: Size): Viewport => {
+  const span = MAP_UNITS * viewport.scale;
+  const visible = Math.min(span, MIN_VISIBLE_PIXELS);
+  return {
+    scale: viewport.scale,
+    offsetX: Math.min(Math.max(viewport.offsetX, visible - span), size.width - visible),
+    offsetY: Math.min(Math.max(viewport.offsetY, visible - span), size.height - visible),
+  };
+};
+
+export interface PinchStart {
+  readonly viewport: Viewport;
+  readonly midpoint: Point;
+  readonly distance: number;
+}
+
+export const midpointOf = (a: Point, b: Point): Point => ({
+  x: (a.x + b.x) / 2,
+  y: (a.y + b.y) / 2,
+});
+
+export const distanceBetween = (a: Point, b: Point): number => Math.hypot(a.x - b.x, a.y - b.y);
+
+/** Two-finger zoom: scale about the starting midpoint, then follow the drag. */
+export const pinchViewport = (
+  start: PinchStart,
+  current: { readonly midpoint: Point; readonly distance: number },
+  fitScale: number,
+): Viewport => {
+  const ratio = start.distance === 0 ? 1 : current.distance / start.distance;
+  const nextScale = clampScale(start.viewport.scale * ratio, fitScale);
+  const zoomed = zoomAt(start.viewport, start.midpoint, nextScale);
+  return panBy(
+    zoomed,
+    current.midpoint.x - start.midpoint.x,
+    current.midpoint.y - start.midpoint.y,
+  );
+};
+
+export const transformAttribute = (viewport: Viewport): string =>
+  `translate(${String(viewport.offsetX)} ${String(viewport.offsetY)}) scale(${String(viewport.scale)})`;
+
+/**
+ * Toolbar reading. 100% means "fits the canvas", which is what it meant before
+ * this change, so the control keeps its old meaning.
+ */
+export const zoomPercent = (viewport: Viewport, fitScale: number): number =>
+  Math.round((viewport.scale / fitScale) * 100);

--- a/apps/web/src/test/fake-api.ts
+++ b/apps/web/src/test/fake-api.ts
@@ -1,12 +1,19 @@
 import type {
   EngineerDashboardResponse,
+  HierarchyNodeView,
+  HierarchyTreeResponse,
   ItemDetailView,
   ItemListResponse,
   ItemSummaryView,
   JobDetailView,
   JobListResponse,
   LocationListResponse,
+  MapRegionInput,
+  MapRegionView,
+  MapSnapshot,
+  MapSummaryView,
   OfficeDashboardResponse,
+  SaveMapRequest,
   StockRequestListResponse,
   StockRequestView,
   TransactionListResponse,
@@ -207,6 +214,153 @@ const users: UserListResponse = {
   ],
 };
 
+/*
+ * Locations and building maps. Region identities are canonical UUIDs because
+ * that is what the server's value objects accept, and the editor now generates
+ * ids for new regions client-side.
+ */
+export const testBranchId = "11111111-1111-4111-8111-111111111111";
+export const testBuildingId = "22222222-2222-4222-8222-222222222222";
+export const testAreaId = "33333333-3333-4333-8333-333333333333";
+export const testAisleId = "44444444-4444-4444-8444-444444444444";
+export const testMapId = "55555555-5555-4555-8555-555555555555";
+export const testRectangleRegionId = "66666666-6666-4666-8666-666666666666";
+export const testPolygonRegionId = "77777777-7777-4777-8777-777777777777";
+
+const hierarchyNode = (
+  overrides: Partial<HierarchyNodeView> & Pick<HierarchyNodeView, "id" | "code" | "name">,
+): HierarchyNodeView => ({
+  nodeKind: "Area",
+  operationalKind: "Storage",
+  parentId: testBuildingId,
+  branchId: testBranchId,
+  buildingId: testBuildingId,
+  status: "Active",
+  generalFulfilmentEnabled: true,
+  children: [],
+  ...overrides,
+});
+
+export const testArea = hierarchyNode({ id: testAreaId, code: "MAIN-A", name: "Aisle A" });
+export const testAisle = hierarchyNode({
+  id: testAisleId,
+  code: "MAIN-B",
+  name: "Aisle B",
+  nodeKind: "Aisle",
+});
+export const testBuilding = hierarchyNode({
+  id: testBuildingId,
+  code: "MAIN",
+  name: "Main warehouse",
+  nodeKind: "Building",
+  parentId: testBranchId,
+  children: [testArea, testAisle],
+});
+export const testBranch = hierarchyNode({
+  id: testBranchId,
+  code: "BR",
+  name: "Northgate branch",
+  nodeKind: "Branch",
+  operationalKind: "Container",
+  parentId: null,
+  buildingId: null,
+  children: [testBuilding],
+});
+
+export const testHierarchyTree: HierarchyTreeResponse = {
+  root: testBranch,
+  buildings: [testBuilding],
+  capabilities: ["manageLocations"],
+};
+
+const availableStock: MapRegionView["stock"] = {
+  status: "Available",
+  colour: "#2E7D32",
+  text: "Available",
+  icon: "check-circle",
+  itemCount: 4,
+  quantity: "120",
+};
+
+export const testRectangleRegion: MapRegionView = {
+  id: testRectangleRegionId,
+  displayName: "Aisle A bays",
+  hierarchyNodeId: testAreaId,
+  parentRegionId: null,
+  geometry: { kind: "Rectangle", x: 0.1, y: 0.1, width: 0.3, height: 0.2 },
+  zOrder: 1,
+  searchAliases: ["bay row"],
+  status: "Active",
+  stock: availableStock,
+};
+
+export const testPolygonRegion: MapRegionView = {
+  id: testPolygonRegionId,
+  displayName: "Aisle B corner",
+  hierarchyNodeId: testAisleId,
+  parentRegionId: null,
+  geometry: {
+    kind: "Polygon",
+    points: [
+      { x: 0.6, y: 0.6 },
+      { x: 0.9, y: 0.6 },
+      { x: 0.75, y: 0.9 },
+    ],
+  },
+  zOrder: 2,
+  searchAliases: [],
+  status: "Active",
+  stock: { ...availableStock, status: "LowStock", colour: "#ED6C02", text: "Low stock" },
+};
+
+export const testMapSnapshot: MapSnapshot = {
+  id: testMapId,
+  buildingId: testBuildingId,
+  building: testBuilding,
+  status: "Active",
+  revision: 3,
+  background: { kind: "Blank" },
+  hierarchy: [testBuilding],
+  regions: [testRectangleRegion, testPolygonRegion],
+  capabilities: ["manageLocations"],
+};
+
+export const testMapSummary: MapSummaryView = {
+  id: testMapId,
+  buildingId: testBuildingId,
+  buildingCode: "MAIN",
+  buildingName: "Main warehouse",
+  status: "Active",
+  revision: 3,
+  background: { kind: "Blank" },
+  regionCount: 2,
+};
+
+/** Turns a save payload back into a snapshot, the way the API would. */
+function savedSnapshot(regions: readonly MapRegionInput[], revision: number): MapSnapshot {
+  return {
+    ...testMapSnapshot,
+    revision: revision + 1,
+    regions: regions.map((region, index) => ({
+      id: region.id ?? `server-${String(index)}`,
+      displayName: region.displayName,
+      hierarchyNodeId: region.hierarchyNodeId,
+      parentRegionId: region.parentRegionId ?? null,
+      geometry: region.geometry,
+      zOrder: region.zOrder,
+      searchAliases: region.searchAliases ?? [],
+      status: region.status ?? "Active",
+      stock: availableStock,
+    })),
+  };
+}
+
+export interface RecordedRequest {
+  readonly method: string;
+  readonly path: string;
+  readonly body: unknown;
+}
+
 function jsonResponse(payload: unknown): Response {
   return new Response(JSON.stringify(payload), {
     status: 200,
@@ -215,11 +369,18 @@ function jsonResponse(payload: unknown): Response {
 }
 
 /** Builds an ApiClient whose every GET resolves against the canned data above. */
-export function createFakeApiClient(overrides: Readonly<Record<string, unknown>> = {}): ApiClient {
-  return new ApiClient((input) => {
+export function createFakeApiClient(
+  overrides: Readonly<Record<string, unknown>> = {},
+  onRequest?: (request: RecordedRequest) => void,
+): ApiClient {
+  return new ApiClient((input, init) => {
     /* The client only ever passes a string path, so this is the whole surface. */
     const url = typeof input === "string" ? input : String((input as URL).href);
     const path = url.replace("/api/v1", "").split("?")[0] ?? "";
+    const method = init?.method ?? "GET";
+    const rawBody = init?.body;
+    const body: unknown = typeof rawBody === "string" ? JSON.parse(rawBody) : undefined;
+    onRequest?.({ method, path, body });
 
     for (const [pattern, payload] of Object.entries(overrides)) {
       if (path === pattern) {
@@ -227,6 +388,39 @@ export function createFakeApiClient(overrides: Readonly<Record<string, unknown>>
       }
     }
 
+    if (path === "/locations/tree") {
+      return Promise.resolve(jsonResponse(testHierarchyTree));
+    }
+    if (path === "/locations/search") {
+      const query = url.includes("query=") ? decodeURIComponent(url.split("query=")[1] ?? "") : "";
+      const matches = [testArea, testAisle].filter((node) =>
+        `${node.name} ${node.code}`.toLowerCase().includes(query.toLowerCase()),
+      );
+      return Promise.resolve(
+        jsonResponse(
+          query.length === 0
+            ? []
+            : matches.map((node) => ({
+                location: node,
+                regionId: node.id === testAreaId ? testRectangleRegionId : testPolygonRegionId,
+                mapId: testMapId,
+                matchedOn: "name",
+              })),
+        ),
+      );
+    }
+    if (path === "/maps") {
+      return Promise.resolve(jsonResponse([testMapSummary]));
+    }
+    if (path === `/maps/${testMapId}` && method === "PUT") {
+      const request = body as SaveMapRequest;
+      return Promise.resolve(
+        jsonResponse(savedSnapshot(request.regions, request.expectedRevision)),
+      );
+    }
+    if (path.startsWith("/maps/")) {
+      return Promise.resolve(jsonResponse(testMapSnapshot));
+    }
     if (path === "/dashboard") {
       return Promise.resolve(jsonResponse(officeDashboard));
     }

--- a/apps/web/src/test/layout.ts
+++ b/apps/web/src/test/layout.ts
@@ -1,0 +1,71 @@
+import { afterEach, vi } from "vitest";
+
+/**
+ * jsdom reports every element as a zero-sized box at the origin, so anything
+ * that converts a pointer position into map coordinates needs a size handed to
+ * it. These helpers supply one, and run animation frames synchronously so a
+ * simulated drag settles inside the test rather than a frame later.
+ */
+
+const originalRectDescriptor = Object.getOwnPropertyDescriptor(
+  Element.prototype,
+  "getBoundingClientRect",
+);
+const restorers: (() => void)[] = [];
+
+export interface CanvasLayout {
+  readonly width: number;
+  readonly height: number;
+  readonly left?: number;
+  readonly top?: number;
+}
+
+/**
+ * Gives every element the supplied box. `Element` rather than `HTMLElement`,
+ * because the canvas is SVG and would otherwise keep reporting zeroes.
+ */
+export function mockCanvasLayout(layout: CanvasLayout): void {
+  const left = layout.left ?? 0;
+  const top = layout.top ?? 0;
+  const rect: DOMRect = {
+    x: left,
+    y: top,
+    left,
+    top,
+    width: layout.width,
+    height: layout.height,
+    right: left + layout.width,
+    bottom: top + layout.height,
+    toJSON: () => ({}),
+  };
+
+  Object.defineProperty(Element.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value: (): DOMRect => rect,
+  });
+  restorers.push(() => {
+    if (originalRectDescriptor !== undefined)
+      Object.defineProperty(Element.prototype, "getBoundingClientRect", originalRectDescriptor);
+  });
+}
+
+/** Makes requestAnimationFrame fire immediately, so rAF-batched work lands now. */
+export function runFramesSynchronously(): void {
+  const frame = vi
+    .spyOn(globalThis, "requestAnimationFrame")
+    .mockImplementation((callback: FrameRequestCallback): number => {
+      callback(performance.now());
+      return 0;
+    });
+  const cancel = vi.spyOn(globalThis, "cancelAnimationFrame").mockImplementation((): void => {
+    /* Frames already ran, so there is nothing to cancel. */
+  });
+  restorers.push(() => {
+    frame.mockRestore();
+    cancel.mockRestore();
+  });
+}
+
+afterEach(() => {
+  for (const restore of restorers.splice(0)) restore();
+});

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -24,6 +24,45 @@ Object.defineProperty(window, "matchMedia", {
   value: vi.fn((query: string) => createMediaQueryList(query, true)),
 });
 
+/*
+ * jsdom has neither a layout engine nor the pointer-capture API, both of which
+ * the map canvas relies on. Stub them so components can mount; tests that care
+ * about geometry install their own sizes with `mockCanvasLayout`.
+ */
+class TestResizeObserver implements ResizeObserver {
+  public constructor(callback: ResizeObserverCallback) {
+    void callback;
+  }
+
+  public observe(): void {
+    /*
+     * Deliberately inert: jsdom never resizes anything, and firing the callback
+     * synchronously from observe() re-enters React during commit. Code that
+     * needs a first measurement takes it itself.
+     */
+  }
+
+  public unobserve(): void {
+    /* Nothing is scheduled, so there is nothing to cancel. */
+  }
+
+  public disconnect(): void {
+    /* Nothing is scheduled, so there is nothing to cancel. */
+  }
+}
+
+globalThis.ResizeObserver = TestResizeObserver;
+
+Element.prototype.setPointerCapture = function setPointerCapture(): void {
+  /* Capture is a no-op here; events already dispatch to the target under test. */
+};
+Element.prototype.releasePointerCapture = function releasePointerCapture(): void {
+  /* See setPointerCapture. */
+};
+Element.prototype.hasPointerCapture = function hasPointerCapture(): boolean {
+  return false;
+};
+
 afterEach((): void => {
   cleanup();
   window.sessionStorage.clear();

--- a/docs/christy-plumbing-heating-style-guide.md
+++ b/docs/christy-plumbing-heating-style-guide.md
@@ -64,33 +64,33 @@ The site should feel designed around a real local business, not assembled from a
 
 ### Primary palette
 
-| Token | Colour | Intended use |
-|---|---:|---|
-| `brand-blue` | `#00309D` | Logo alignment, primary buttons, key headings, links and navigation accents |
-| `brand-blue-dark` | `#002477` | Hover states, dark panels and stronger text-on-light emphasis |
-| `brand-blue-deep` | `#071B3A` | Footer, hero overlays and high-contrast sections |
-| `brand-blue-pale` | `#EAF0FC` | Service-card backgrounds, highlighted information and alternating sections |
-| `white` | `#FFFFFF` | Main backgrounds and text on dark blue |
-| `off-white` | `#F7F8FA` | Soft page sections that need separation from white |
+| Token             |    Colour | Intended use                                                                |
+| ----------------- | --------: | --------------------------------------------------------------------------- |
+| `brand-blue`      | `#00309D` | Logo alignment, primary buttons, key headings, links and navigation accents |
+| `brand-blue-dark` | `#002477` | Hover states, dark panels and stronger text-on-light emphasis               |
+| `brand-blue-deep` | `#071B3A` | Footer, hero overlays and high-contrast sections                            |
+| `brand-blue-pale` | `#EAF0FC` | Service-card backgrounds, highlighted information and alternating sections  |
+| `white`           | `#FFFFFF` | Main backgrounds and text on dark blue                                      |
+| `off-white`       | `#F7F8FA` | Soft page sections that need separation from white                          |
 
 ### Neutral palette
 
-| Token | Colour | Intended use |
-|---|---:|---|
-| `text-strong` | `#172033` | Headings and important body copy |
-| `text-body` | `#3F4858` | Standard paragraph text |
-| `text-muted` | `#687386` | Metadata, captions and secondary details |
-| `border` | `#DCE2EA` | Cards, fields and dividers |
-| `surface-dark` | `#101828` | Optional dark content surfaces |
+| Token          |    Colour | Intended use                             |
+| -------------- | --------: | ---------------------------------------- |
+| `text-strong`  | `#172033` | Headings and important body copy         |
+| `text-body`    | `#3F4858` | Standard paragraph text                  |
+| `text-muted`   | `#687386` | Metadata, captions and secondary details |
+| `border`       | `#DCE2EA` | Cards, fields and dividers               |
+| `surface-dark` | `#101828` | Optional dark content surfaces           |
 
 ### Functional colours
 
-| Token | Colour | Intended use |
-|---|---:|---|
-| `urgent` | `#C2410C` | Emergency-only labels and urgent actions |
+| Token     |    Colour | Intended use                                |
+| --------- | --------: | ------------------------------------------- |
+| `urgent`  | `#C2410C` | Emergency-only labels and urgent actions    |
 | `success` | `#18794E` | Confirmation messages and valid form states |
-| `warning` | `#B45309` | Important notices |
-| `error` | `#B42318` | Form errors and destructive actions |
+| `warning` | `#B45309` | Important notices                           |
+| `error`   | `#B42318` | Form errors and destructive actions         |
 
 ### Colour rules
 
@@ -116,15 +116,15 @@ Alternative heading fonts that could work are **Libre Baskerville** or **Source 
 
 ### Usage
 
-| Element | Typeface | Suggested weight | Notes |
-|---|---|---:|---|
-| Display heading | Serif | 400 | Use for the main hero statement only |
-| H1–H3 | Serif | 400 | Keep wording direct and relatively short |
-| H4–H6 | Sans-serif | 600–700 | Better for card titles and compact sections |
-| Body | Sans-serif | 400 | Optimise for readability |
-| Navigation | Sans-serif | 600 | Avoid all caps |
-| Buttons | Sans-serif | 650–700 | Short action-led labels |
-| Labels/captions | Sans-serif | 500–600 | Use sparingly |
+| Element         | Typeface   | Suggested weight | Notes                                       |
+| --------------- | ---------- | ---------------: | ------------------------------------------- |
+| Display heading | Serif      |              400 | Use for the main hero statement only        |
+| H1–H3           | Serif      |              400 | Keep wording direct and relatively short    |
+| H4–H6           | Sans-serif |          600–700 | Better for card titles and compact sections |
+| Body            | Sans-serif |              400 | Optimise for readability                    |
+| Navigation      | Sans-serif |              600 | Avoid all caps                              |
+| Buttons         | Sans-serif |          650–700 | Short action-led labels                     |
+| Labels/captions | Sans-serif |          500–600 | Use sparingly                               |
 
 ### Suggested scale
 

--- a/docs/locations-maps.md
+++ b/docs/locations-maps.md
@@ -5,6 +5,30 @@ receive the `manageLocations` capability and can create hierarchy nodes, start
 blank building maps, draw rectangles or polygons, move regions with the arrow
 keys, and save a complete snapshot.
 
+## Editor controls
+
+| Input                                            | Action                                                                                                           |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| Drag a region, or its corner handles             | Move or resize it                                                                                                |
+| Arrow keys                                       | Nudge the selected region; Shift moves farther                                                                   |
+| Delete or Backspace                              | Remove the selected region                                                                                       |
+| Rectangle tool                                   | Drag to draw; the outline follows the pointer                                                                    |
+| Polygon tool                                     | Click to add points; click the first point or press Enter to finish, Backspace to undo a point, Escape to cancel |
+| Snap toggle                                      | Aligns to a 1% grid; hold Alt to place freely                                                                    |
+| Ctrl/⌘ + wheel, or trackpad pinch                | Zoom towards the pointer                                                                                         |
+| Wheel, or two-finger scroll                      | Pan; Shift swaps the axes                                                                                        |
+| Space + drag, middle-mouse drag, or the Pan tool | Pan                                                                                                              |
+| `+` / `-` / `0`                                  | Zoom in, zoom out, fit to the canvas                                                                             |
+| Tab inside the canvas                            | Move the selection through the regions                                                                           |
+
+The canvas is a single tab stop that moves an `aria-activedescendant`, rather
+than one tab stop per region. Zoom is reported relative to the fitted view, so
+100% means the map fills the canvas.
+
+Drag geometry is held outside React state and published once per animation
+frame, so a drag re-renders only the shape being moved. The committed change
+reaches the editor's reducer once, when the pointer is released.
+
 The `locations` table remains the stock system's source of truth. Existing IDs,
 codes, balances, jobs, and transactions are retained by migration `0004`. A
 region is only a visual link to one hierarchy node; containing one SVG shape in

--- a/packages/platform/database/src/schema.ts
+++ b/packages/platform/database/src/schema.ts
@@ -118,7 +118,13 @@ export interface MapRegionsTable {
   readonly display_name: string;
   readonly geometry: JSONColumnType<JsonObject, JsonObject, JsonObject>;
   readonly z_order: number;
-  readonly search_aliases: JSONColumnType<readonly string[], readonly string[], readonly string[]>;
+  /*
+   * Written as serialised JSON, not as an array. node-postgres turns a JS array
+   * parameter into a PostgreSQL array literal — `{"north cache"}` — which a
+   * jsonb column rejects. Objects happen to serialise correctly, which is why
+   * `geometry` above works and this did not.
+   */
+  readonly search_aliases: JSONColumnType<readonly string[], string, string>;
   readonly status: Generated<MapRegionStatus>;
   readonly created_at: GeneratedImmutableColumn<Date>;
   readonly updated_at: Generated<Date>;


### PR DESCRIPTION
Dragging a region re-rendered the entire 1842-line LocationsPage on every
pointer move — the hierarchy tree, five MUI selects with their full option
lists, the toolbar and the inspector, at pointer-event rate. Two other faults
compounded it: pointer positions were measured across the element box while
the SVG letterboxed its own coordinate system, so shapes landed away from the
cursor; and the Pan tool, zoom-beyond-fit and Raise/Lower were inert.

Split the page into apps/web/src/pages/locations/. In-flight drag geometry now
lives in a small external store that only the shape being moved subscribes to,
fed by one requestAnimationFrame per paint, with a single reducer dispatch on
release. Measured over a 150-region map: 60fps drags (median 16.7ms frame
interval, p95 18.0ms) and no sidebar re-render mid-gesture.

Viewport: the canvas drops its viewBox so user units are CSS pixels, and pan
and zoom compose in one group transform. Adds wheel/pinch zoom to the cursor,
wheel and space-drag and middle-mouse panning, a working Pan tool, fit-to-view
and keyboard zoom. Pointer capture makes a drag survive leaving the canvas and
removes the stuck-drag bug.

Also: live rectangle and polygon previews with click-to-close, z-order-aware
paint order, Delete to remove a region, a grid-snap toggle with Alt override,
roving tabindex in place of a tab stop per region and handle, debounced
location search, and a lazy route so the editor leaves the initial bundle.

Fixes three latent save failures found on the way: a region drawn in the same
millisecond as another shared its id, choosing an unsaved region as a visual
parent sent an id the server rejects, and deleting a region left its children
orphaned.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DL6FgBMm7BwNhjjKfnqZ7H