### PR TITLE
fix(web): make the interface say what it means and hide what a role cannot use

### DIFF
--- a/apps/api/src/persistence/read-models.ts
+++ b/apps/api/src/persistence/read-models.ts
@@ -730,6 +730,7 @@ export async function jobSiteStock(
       "locations.kind as kind",
       "items.reference as item_reference",
       "items.name as item_name",
+      "items.unit as item_unit",
     ])
     .where("stock_levels.location_id", "=", locationId)
     .where("stock_levels.quantity", ">", "0")
@@ -742,5 +743,6 @@ export async function jobSiteStock(
     locationName: `${row.item_reference} — ${row.item_name}`,
     kind: row.kind,
     quantity: row.quantity,
+    unit: row.item_unit,
   }));
 }

--- a/apps/e2e/tests/demo-journey.spec.ts
+++ b/apps/e2e/tests/demo-journey.spec.ts
@@ -162,8 +162,8 @@ test("the demo journey: create, receive, reserve, collect, and account for it", 
   });
 
   await expect(stat(page, "On hand")).toHaveText("40 each");
-  await expect(stat(page, "In stores")).toHaveText("40");
-  await expect(stat(page, "Available")).toHaveText("40");
+  await expect(stat(page, "In stores")).toHaveText("40 each");
+  await expect(stat(page, "Available")).toHaveText("40 each");
 
   /* Reserve 15 against a job: availability drops, on hand does not move. */
   await page.goto("/jobs");
@@ -187,8 +187,8 @@ test("the demo journey: create, receive, reserve, collect, and account for it", 
 
   await page.goto(itemUrl);
   await expect(stat(page, "On hand")).toHaveText("40 each");
-  await expect(stat(page, "Reserved")).toHaveText("15");
-  await expect(stat(page, "Available")).toHaveText("25");
+  await expect(stat(page, "Reserved")).toHaveText("15 each");
+  await expect(stat(page, "Available")).toHaveText("25 each");
 
   /* Collect 6 of the 15: the remaining 9 stays reserved. */
   await page.goto(jobUrl);
@@ -201,9 +201,9 @@ test("the demo journey: create, receive, reserve, collect, and account for it", 
   await expect(collectDialog).toBeHidden();
 
   /* Reserved, collected, outstanding — and still open on the remainder. */
-  await expect(reservationRow.locator("td").nth(1)).toHaveText("15");
-  await expect(reservationRow.locator("td").nth(2)).toHaveText("6");
-  await expect(reservationRow.locator("td").nth(3)).toHaveText("9");
+  await expect(reservationRow.locator("td").nth(1)).toHaveText("15 each");
+  await expect(reservationRow.locator("td").nth(2)).toHaveText("6 each");
+  await expect(reservationRow.locator("td").nth(3)).toHaveText("9 each");
   await expect(reservationRow).toContainText("Open");
   await expect(
     page.getByRole("table", { name: "Stock at the job site" }).filter({ hasText: reference }),
@@ -216,10 +216,10 @@ test("the demo journey: create, receive, reserve, collect, and account for it", 
    */
   await page.goto(itemUrl);
   await expect(stat(page, "On hand")).toHaveText("40 each");
-  await expect(stat(page, "In stores")).toHaveText("34");
-  await expect(stat(page, "At job sites")).toHaveText("6");
-  await expect(stat(page, "Reserved")).toHaveText("9");
-  await expect(stat(page, "Available")).toHaveText("25");
+  await expect(stat(page, "In stores")).toHaveText("34 each");
+  await expect(stat(page, "At job sites")).toHaveText("6 each");
+  await expect(stat(page, "Reserved")).toHaveText("9 each");
+  await expect(stat(page, "Available")).toHaveText("25 each");
 
   /* Every one of those changes is in the log, against the person who made it. */
   const actor = await signedInName(page);
@@ -262,9 +262,9 @@ test("transferring keeps the total, and an adjustment records its reason", async
     page.getByRole("table", { name: "Stock by location" }).locator("tbody tr"),
   ).toHaveCount(2);
 
-  await runOperation(page, { open: "Adjust", submit: "Post adjustment" }, async (dialog) => {
+  await runOperation(page, { open: "Adjust", submit: "Save new count" }, async (dialog) => {
     await chooseOption(page, dialog, "Location");
-    await dialog.getByLabel("Counted quantity").fill("25");
+    await dialog.getByLabel("Total counted").fill("25");
     await dialog.getByLabel("Reason").fill("Cycle count during the demo");
   });
 
@@ -307,11 +307,11 @@ test("an over-issue is refused with what is actually on the shelf", async ({ pag
     await dialog.getByLabel("Quantity").fill("12");
   });
 
-  await page.getByRole("button", { name: "Issue", exact: true }).click();
+  await page.getByRole("button", { name: "Take out", exact: true }).click();
   const dialog = page.getByRole("dialog");
   await chooseOption(page, dialog, "Location");
   await dialog.getByLabel("Quantity").fill("40");
-  await dialog.getByRole("button", { name: "Issue", exact: true }).click();
+  await dialog.getByRole("button", { name: "Take out", exact: true }).click();
 
   await expect(dialog.getByRole("alert")).toContainText("Cannot issue 40");
   await expect(dialog.getByRole("alert")).toContainText("12");
@@ -350,7 +350,7 @@ test("a scanned item opens after signing in, on a phone", async ({ page, context
   await expect(page.getByRole("img", { name: /QR code linking to/ })).toBeVisible();
 
   /* An Engineer who arrives by camera still only gets an Engineer's controls. */
-  await expect(page.getByRole("button", { name: "Issue", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Take out", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Receive" })).toHaveCount(0);
 });
 
@@ -370,7 +370,7 @@ test("role decides which sections and controls are offered", async ({ page }) =>
   await expect(page.getByRole("link", { name: "Transactions" })).toBeVisible();
 
   await page.getByRole("table", { name: "Inventory" }).getByRole("link").first().click();
-  await expect(page.getByRole("button", { name: "Issue" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Take out" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Request stock" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Receive" })).toHaveCount(0);
 });
@@ -394,6 +394,13 @@ test("an Engineer's log holds only their own activity", async ({ page }) => {
 
 /* The purchasing loop the MVP left out: ask, then have somebody decide. */
 test("an Engineer requests stock and the Office decides it", async ({ page }) => {
+  /*
+   * Unique per run, like the item names above. A request is never cleaned up,
+   * so a fixed note accumulates one matching element per run and per retry
+   * until the lookup below dies on strict mode.
+   */
+  const note = `Needed for Friday. ${Date.now()}`;
+
   await signIn(page, ENGINEER);
   await page.goto("/dashboard");
 
@@ -402,13 +409,13 @@ test("an Engineer requests stock and the Office decides it", async ({ page }) =>
 
   const dialog = page.getByRole("dialog");
   await dialog.getByRole("textbox", { name: /Quantity/ }).fill("7");
-  await dialog.getByRole("textbox", { name: "Note (optional)" }).fill("Needed for Friday.");
+  await dialog.getByRole("textbox", { name: "Note (optional)" }).fill(note);
   await dialog.getByRole("button", { name: "Send request" }).click();
 
   await expect(dialog).toHaveCount(0);
   await page.goto("/dashboard");
   await expect(page.getByRole("heading", { name: "Your stock requests" })).toBeVisible();
-  await expect(page.getByText("Needed for Friday.")).toBeVisible();
+  await expect(page.getByText(note)).toBeVisible();
 
   await page.getByRole("button", { name: "Sign out" }).click();
   await expect(page).toHaveURL(/\/sign-in$/);
@@ -416,9 +423,9 @@ test("an Engineer requests stock and the Office decides it", async ({ page }) =>
   await signIn(page, OFFICE);
   await page.goto("/requests");
 
-  const request = page.locator("li").filter({ hasText: "Needed for Friday." }).first();
+  const request = page.locator("li").filter({ hasText: note }).first();
   await expect(request).toBeVisible();
-  await request.getByRole("button", { name: "Reject" }).click();
+  await request.getByRole("button", { name: "Turn down" }).click();
 
   const decision = page.getByRole("dialog");
   await decision
@@ -469,14 +476,14 @@ test("the transaction log accounts for activity with its actor", async ({ page }
   const log = page.getByRole("table", { name: "Transaction log" });
   await expect(log).toBeVisible();
   await expect(log.locator("tbody tr").first()).toContainText(
-    /Receive|Issue|Transfer|Collect|Adjust/,
+    /Receive|Take out|Transfer|Collect|Adjust/,
   );
 
   /* The filter takes the reference people read off a label, not an internal id. */
   await page.getByLabel("Item", { exact: true }).fill("ITM-0001");
   await expect(log.locator("tbody tr").first()).toBeVisible();
   await expect(log.locator("tbody tr").first()).toContainText(
-    /Receive|Issue|Transfer|Collect|Adjust/,
+    /Receive|Take out|Transfer|Collect|Adjust/,
   );
 });
 

--- a/apps/web/src/api/ApiClient.ts
+++ b/apps/web/src/api/ApiClient.ts
@@ -56,6 +56,18 @@ export class ApiError extends Error {
     return this.errors?.[field]?.[0];
   }
 
+  /**
+   * Whether every part of this failure is already spoken for by a field.
+   *
+   * A form that shows "Enter a location." under the empty select does not also
+   * need "Validation failed" shouted above it — the banner adds a word nobody
+   * outside software uses and says less than the message beneath it. A dialog
+   * uses this to keep the summary for failures the fields cannot explain.
+   */
+  public get hasFieldErrors(): boolean {
+    return Object.keys(this.errors ?? {}).length > 0;
+  }
+
   public get isValidation(): boolean {
     return this.status === 422;
   }

--- a/apps/web/src/components/CreateItemDialog.tsx
+++ b/apps/web/src/components/CreateItemDialog.tsx
@@ -70,7 +70,7 @@ export function CreateItemDialog({
       <form onSubmit={handleSubmit} noValidate>
         <DialogContent dividers>
           <Stack spacing={2.5}>
-            {error !== undefined && (
+            {error !== undefined && !error.hasFieldErrors && (
               <Alert severity={error.isPermissionDenied ? "warning" : "error"} role="alert">
                 {error.message}
               </Alert>
@@ -110,7 +110,7 @@ export function CreateItemDialog({
               helperText="Optional, and searchable"
             />
             <TextField
-              label="Low-stock threshold"
+              label="Low-stock minimum"
               value={threshold}
               onChange={(event) => setThreshold(event.target.value)}
               disabled={submitting}

--- a/apps/web/src/components/DataStates.tsx
+++ b/apps/web/src/components/DataStates.tsx
@@ -2,9 +2,26 @@ import ErrorOutlineRounded from "@mui/icons-material/ErrorOutlineRounded";
 import InboxRounded from "@mui/icons-material/InboxRounded";
 import LockOutlined from "@mui/icons-material/LockOutlined";
 import { Alert, AlertTitle, Box, Button, Paper, Skeleton, Stack, Typography } from "@mui/material";
+import type { TransactionKind } from "@stockcontrol/contracts";
 import type { ReactElement, ReactNode } from "react";
 
 import type { ApiError } from "../api/ApiClient";
+
+/**
+ * What each kind of movement is called on screen. The stored kind is `Issue`,
+ * but every button that performs one says "Take out", so the history says the
+ * same thing — one movement should not have two names depending on which page
+ * you are looking at. Every screen that shows a transaction reads from here.
+ */
+export const transactionKindLabels: Readonly<Record<TransactionKind, string>> = {
+  Receive: "Receive",
+  Issue: "Take out",
+  Transfer: "Transfer",
+  Adjust: "Adjust",
+  Reserve: "Reserve",
+  Collect: "Collect",
+  Release: "Release",
+};
 
 /** Trims trailing zeros so a table reads "7" and "7.5", not "7.000". */
 export function formatQuantity(value: string): string {

--- a/apps/web/src/components/InventoryTable.tsx
+++ b/apps/web/src/components/InventoryTable.tsx
@@ -204,7 +204,7 @@ export function InventoryTable({
       "stockcontrol-inventory.csv",
       toCsv(
         [
-          "Item ID",
+          "Item code",
           "Name",
           "Unit",
           "On hand",
@@ -291,7 +291,7 @@ export function InventoryTable({
               <TableHead>
                 <TableRow>
                   <TableCell padding="checkbox" />
-                  <TableCell sx={{ whiteSpace: "nowrap" }}>Item ID</TableCell>
+                  <TableCell sx={{ whiteSpace: "nowrap" }}>Item code</TableCell>
                   <TableCell>Name</TableCell>
                   <TableCell align="right" sx={{ display: { xs: "none", sm: "table-cell" } }}>
                     On hand
@@ -301,7 +301,7 @@ export function InventoryTable({
                   </TableCell>
                   {showReservedForYou && (
                     <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
-                      For you
+                      Reserved for you
                     </TableCell>
                   )}
                   <TableCell align="right">Available</TableCell>

--- a/apps/web/src/components/RouteStates.tsx
+++ b/apps/web/src/components/RouteStates.tsx
@@ -165,7 +165,7 @@ export function AccessDeniedPage(): ReactElement {
       <StatePanel
         eyebrow="Permission required"
         title="Access restricted"
-        description="Your current role does not include this workspace. Ask an Admin if you need access for your work."
+        description="Your current role does not include this section. Ask an Admin if you need access for your work."
         icon={<LockOutlined />}
         actionLabel="Return to overview"
         onAction={() => {

--- a/apps/web/src/components/StockOperationDialog.tsx
+++ b/apps/web/src/components/StockOperationDialog.tsx
@@ -23,14 +23,19 @@ const titles: Readonly<Record<StockOperation, string>> = {
   receive: "Receive stock",
   issue: "Take out stock",
   transfer: "Transfer stock",
-  adjust: "Adjust count",
+  /*
+   * "Adjust" on its own suggests a difference — add three, take two away — but
+   * the field below is the new total. Someone who counts five boxes on a shelf
+   * holding six hundred should be in no doubt which number to type.
+   */
+  adjust: "Correct the counted quantity",
 };
 
 const submitLabels: Readonly<Record<StockOperation, string>> = {
   receive: "Receive",
   issue: "Take out",
   transfer: "Transfer",
-  adjust: "Post adjustment",
+  adjust: "Save new count",
 };
 
 interface StockOperationDialogProps {
@@ -134,7 +139,7 @@ export function StockOperationDialog({
               {item.reference} — {item.name}
             </Typography>
 
-            {error !== undefined && (
+            {error !== undefined && !error.hasFieldErrors && (
               <Alert severity={error.isPermissionDenied ? "warning" : "error"} role="alert">
                 {error.message}
               </Alert>
@@ -185,7 +190,7 @@ export function StockOperationDialog({
 
             <TextField
               required
-              label={operation === "adjust" ? "Counted quantity" : "Quantity"}
+              label={operation === "adjust" ? "Total counted" : "Quantity"}
               value={quantity}
               onChange={(event) => setQuantity(event.target.value)}
               disabled={submitting}
@@ -194,12 +199,21 @@ export function StockOperationDialog({
                 error?.fieldError("quantity") !== undefined ||
                 error?.fieldError("countedQuantity") !== undefined
               }
+              /*
+               * The replaces-not-adds sentence shows whether or not a location
+               * has been picked yet. It is the one thing a person must know
+               * before typing, so it cannot wait for the figure to appear.
+               */
               helperText={
                 error?.fieldError("quantity") ??
                 error?.fieldError("countedQuantity") ??
-                (operation === "adjust" && currentAtLocation !== undefined
-                  ? `Currently recorded: ${formatQuantity(currentAtLocation)} ${item.unit}`
-                  : `In ${item.unit}`)
+                (operation === "adjust"
+                  ? `Enter the total you counted — it replaces the figure on record, it is not added to it.${
+                      currentAtLocation === undefined
+                        ? ""
+                        : ` Currently recorded: ${formatQuantity(currentAtLocation)} ${item.unit}.`
+                    }`
+                  : `Quantity in ${item.unit}`)
               }
             />
 

--- a/apps/web/src/components/StockRequestDialog.tsx
+++ b/apps/web/src/components/StockRequestDialog.tsx
@@ -118,7 +118,7 @@ export function StockRequestDialog({
               fullWidth
             />
 
-            {error !== null && error.errors === undefined && (
+            {error !== null && !error.hasFieldErrors && (
               <Alert severity={error.isPermissionDenied ? "warning" : "error"}>
                 {error.message}
               </Alert>

--- a/apps/web/src/components/StockRequestList.tsx
+++ b/apps/web/src/components/StockRequestList.tsx
@@ -34,7 +34,7 @@ const STATUS_COLOURS: Readonly<Record<StockRequestStatus, StatusColour>> = {
 
 interface StockRequestListProps {
   readonly requests: readonly StockRequestView[];
-  /** Whether to offer Approve and Reject. The server checks this again. */
+  /** Whether to offer Approve and Turn down. The server checks this again. */
   readonly canReview: boolean;
   readonly onChanged?: () => void;
 }
@@ -168,7 +168,7 @@ export function StockRequestList({
                         Approve
                       </Button>
                       <Button size="small" onClick={() => open(request, "reject")}>
-                        Reject
+                        Turn down
                       </Button>
                     </>
                   )}
@@ -229,7 +229,7 @@ export function StockRequestList({
               />
             )}
 
-            {error !== null && (
+            {error !== null && !error.hasFieldErrors && (
               <Alert severity={error.isPermissionDenied ? "warning" : "error"}>
                 {error.message}
               </Alert>

--- a/apps/web/src/layout/AppShell.tsx
+++ b/apps/web/src/layout/AppShell.tsx
@@ -306,6 +306,12 @@ export function AppShell(): ReactElement | null {
             mx: "auto",
             px: { xs: 2, sm: 3, lg: 4 },
             py: isLocationWorkspace ? { xs: 1.5, md: 2 } : { xs: 2.5, md: 4 },
+            /*
+             * The scan button floats over the bottom-right corner. Without this
+             * it lands on the last row of a long table — the one you scrolled
+             * all the way down to read.
+             */
+            pb: isLocationWorkspace ? { xs: 1.5, md: 2 } : { xs: 12, md: 12 },
             height: isLocationWorkspace ? "100%" : undefined,
             display: isLocationWorkspace ? "flex" : undefined,
             flexDirection: isLocationWorkspace ? "column" : undefined,

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -25,6 +25,7 @@ import { Link as RouterLink } from "react-router-dom";
 
 import { useApi, useResource } from "../api/ApiContext";
 import { useAuth } from "../auth/AuthContext";
+import { useCapability } from "../auth/useCapability";
 import {
   ErrorState,
   formatDateTime,
@@ -32,6 +33,7 @@ import {
   LoadingRows,
   PageHeader,
   StatTile,
+  transactionKindLabels,
 } from "../components/DataStates";
 import { InventoryTable } from "../components/InventoryTable";
 import { StockRequestList } from "../components/StockRequestList";
@@ -178,7 +180,9 @@ function EngineerDashboard({
                         key={`${job.id}-${balance.locationName}`}
                         size="small"
                         variant="outlined"
-                        label={`${balance.locationName} · ${formatQuantity(balance.quantity)}`}
+                        label={`${balance.locationName} · ${formatQuantity(balance.quantity)}${
+                          balance.unit === undefined ? "" : ` ${balance.unit}`
+                        }`}
                       />
                     ))}
                   </Stack>
@@ -220,6 +224,12 @@ function OfficeDashboard({
 }): ReactElement {
   const [mineOnly, setMineOnly] = useState(false);
   const reservations = mineOnly ? data.myReservations : data.openReservations;
+  /*
+   * Only roles that hold the capability get Approve and Turn down. Reaching
+   * this component already implies the role, but the guard belongs on the
+   * capability rather than on which branch rendered us.
+   */
+  const canReview = useCapability("reviewStockRequests");
 
   return (
     <Stack spacing={3}>
@@ -244,7 +254,7 @@ function OfficeDashboard({
         }
       >
         {data.lowStock.length === 0 ? (
-          <Empty>Nothing is below its threshold.</Empty>
+          <Empty>Nothing is below its minimum.</Empty>
         ) : (
           <List disablePadding>
             {data.lowStock.map((item) => (
@@ -255,9 +265,14 @@ function OfficeDashboard({
                       {item.reference} — {item.name}
                     </Link>
                   }
-                  secondary={`${formatQuantity(item.available)} ${item.unit} available, threshold ${formatQuantity(item.lowStockThreshold ?? "0")}`}
+                  secondary={`${formatQuantity(item.available)} ${item.unit} available, minimum ${formatQuantity(item.lowStockThreshold ?? "0")}`}
                 />
-                <Chip label="Reorder" size="small" color="warning" variant="outlined" />
+                {/*
+                 * A state, not an instruction. "Reorder" reads as a button that
+                 * places an order, and nothing here does that — this is the same
+                 * condition the inventory table flags, so it wears the same word.
+                 */}
+                <Chip label="Low" size="small" color="warning" variant="outlined" />
               </ListItem>
             ))}
           </List>
@@ -275,7 +290,11 @@ function OfficeDashboard({
         {data.pendingRequests.length === 0 ? (
           <Empty>Nothing is waiting for a decision.</Empty>
         ) : (
-          <StockRequestList requests={data.pendingRequests} canReview onChanged={onChanged} />
+          <StockRequestList
+            requests={data.pendingRequests}
+            canReview={canReview}
+            onChanged={onChanged}
+          />
         )}
       </Panel>
 
@@ -361,7 +380,11 @@ function OfficeDashboard({
                       alignItems="center"
                       sx={{ flexWrap: "wrap" }}
                     >
-                      <Chip label={transaction.kind} size="small" variant="outlined" />
+                      <Chip
+                        label={transactionKindLabels[transaction.kind]}
+                        size="small"
+                        variant="outlined"
+                      />
                       <Link
                         component={RouterLink}
                         to={`/inventory/${transaction.itemId}`}

--- a/apps/web/src/pages/InventoryPage.tsx
+++ b/apps/web/src/pages/InventoryPage.tsx
@@ -24,7 +24,7 @@ export function InventoryPage(): ReactElement {
       <PageHeader
         eyebrow="Inventory"
         title="What you have, and where"
-        description="Search by item ID, name, barcode or part number. Expand a row to see the per-location breakdown."
+        description="Search by item code, name, barcode or part number. Expand a row to see the per-location breakdown. Available is what is free to take: it counts stores only, never stock already dropped at a job site."
         actions={
           <Stack direction="row" spacing={1.5}>
             <Button

--- a/apps/web/src/pages/ItemDetailPage.tsx
+++ b/apps/web/src/pages/ItemDetailPage.tsx
@@ -5,6 +5,11 @@ import {
   Box,
   Button,
   Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   Divider,
   Paper,
   Stack,
@@ -31,6 +36,7 @@ import {
   LoadingRows,
   PageHeader,
   StatTile,
+  transactionKindLabels,
 } from "../components/DataStates";
 import { ItemQrCode } from "../components/ItemQrCode";
 import { isValidEan13, ItemBarcode } from "../components/ItemBarcode";
@@ -50,6 +56,7 @@ export function ItemDetailPage(): ReactElement {
   const [requesting, setRequesting] = useState(false);
   const [editing, setEditing] = useState(false);
   const [archiving, setArchiving] = useState(false);
+  const [confirmingArchive, setConfirmingArchive] = useState(false);
 
   const loadItem = useCallback((signal: AbortSignal) => api.getItem(itemId, signal), [api, itemId]);
   const loadLocations = useCallback((signal: AbortSignal) => api.listLocations(signal), [api]);
@@ -74,7 +81,10 @@ export function ItemDetailPage(): ReactElement {
     setArchiving(true);
     void api
       .updateItem(data.id, { isActive: !data.isActive })
-      .then(() => item.reload())
+      .then(() => {
+        setConfirmingArchive(false);
+        return item.reload();
+      })
       .finally(() => setArchiving(false));
   };
 
@@ -151,7 +161,13 @@ export function ItemDetailPage(): ReactElement {
                     <Button variant="text" onClick={() => setEditing(true)}>
                       Edit
                     </Button>
-                    <Button variant="text" onClick={toggleArchived} disabled={archiving}>
+                    <Button
+                      variant="text"
+                      onClick={() =>
+                        data.isActive ? setConfirmingArchive(true) : toggleArchived()
+                      }
+                      disabled={archiving}
+                    >
                       {data.isActive ? "Archive" : "Restore"}
                     </Button>
                   </>
@@ -168,19 +184,41 @@ export function ItemDetailPage(): ReactElement {
           )}
 
           <Stack spacing={3}>
+            {/*
+             * Five figures that only make sense in relation to each other, so
+             * each says what it counts. Every one carries the unit: a row where
+             * the first tile reads "677 ea" and the rest read "677" invites you
+             * to read them as different things.
+             */}
             <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-              <StatTile label="On hand" value={`${formatQuantity(data.onHand)} ${data.unit}`} />
-              <StatTile label="In stores" value={formatQuantity(data.inStores)} />
-              <StatTile label="At job sites" value={formatQuantity(data.atJobSites)} />
-              <StatTile label="Reserved" value={formatQuantity(data.reserved)} />
+              <StatTile
+                label="On hand"
+                value={`${formatQuantity(data.onHand)} ${data.unit}`}
+                caption="Everything, everywhere"
+              />
+              <StatTile
+                label="In stores"
+                value={`${formatQuantity(data.inStores)} ${data.unit}`}
+                caption="Back at the stores"
+              />
+              <StatTile
+                label="At job sites"
+                value={`${formatQuantity(data.atJobSites)} ${data.unit}`}
+                caption="Already collected to site"
+              />
+              <StatTile
+                label="Reserved"
+                value={`${formatQuantity(data.reserved)} ${data.unit}`}
+                caption="Committed to a job, not yet moved"
+              />
               <StatTile
                 label="Available"
-                value={formatQuantity(data.available)}
+                value={`${formatQuantity(data.available)} ${data.unit}`}
                 tone={data.belowThreshold ? "warning" : "primary"}
                 caption={
                   data.lowStockThreshold === null
-                    ? undefined
-                    : `Threshold ${formatQuantity(data.lowStockThreshold)}`
+                    ? "Free to take from stores"
+                    : `Free to take · minimum ${formatQuantity(data.lowStockThreshold)}`
                 }
               />
             </Stack>
@@ -203,7 +241,7 @@ export function ItemDetailPage(): ReactElement {
                       <TableHead>
                         <TableRow>
                           <TableCell>Location</TableCell>
-                          <TableCell>Kind</TableCell>
+                          <TableCell>Type</TableCell>
                           <TableCell align="right">Quantity</TableCell>
                         </TableRow>
                       </TableHead>
@@ -346,7 +384,11 @@ export function ItemDetailPage(): ReactElement {
                             {formatDateTime(transaction.occurredAt)}
                           </TableCell>
                           <TableCell>
-                            <Chip label={transaction.kind} size="small" variant="outlined" />
+                            <Chip
+                              label={transactionKindLabels[transaction.kind]}
+                              size="small"
+                              variant="outlined"
+                            />
                           </TableCell>
                           <TableCell align="right">
                             {formatQuantity(transaction.quantity)}
@@ -395,6 +437,35 @@ export function ItemDetailPage(): ReactElement {
               }}
             />
           )}
+
+          {/*
+           * Archiving is undone by the Restore button next to it, so this is a
+           * short question rather than a warning — but it sits one pixel from
+           * Edit, and it stops the item being used, so it should not fire on a
+           * misclick.
+           */}
+          <Dialog
+            open={confirmingArchive}
+            onClose={() => setConfirmingArchive(false)}
+            fullWidth
+            maxWidth="xs"
+          >
+            <DialogTitle>Archive {data.reference}?</DialogTitle>
+            <DialogContent>
+              <DialogContentText>
+                It cannot be received, taken out or reserved while archived, and it drops out of the
+                catalogue search. Its history is kept, and Restore brings it back.
+              </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={() => setConfirmingArchive(false)} disabled={archiving}>
+                Cancel
+              </Button>
+              <Button variant="contained" onClick={toggleArchived} disabled={archiving}>
+                {archiving ? "Archiving…" : "Archive"}
+              </Button>
+            </DialogActions>
+          </Dialog>
         </>
       )}
     </Box>

--- a/apps/web/src/pages/JobDetailPage.tsx
+++ b/apps/web/src/pages/JobDetailPage.tsx
@@ -8,6 +8,7 @@ import {
   Dialog,
   DialogActions,
   DialogContent,
+  DialogContentText,
   DialogTitle,
   Divider,
   Link,
@@ -37,6 +38,7 @@ import {
   LoadingRows,
   PageHeader,
   StatTile,
+  transactionKindLabels,
 } from "../components/DataStates";
 
 function asApiError(caught: unknown): ApiError {
@@ -102,7 +104,7 @@ function ReserveDialog({
       <form onSubmit={handleSubmit} noValidate>
         <DialogContent dividers>
           <Stack spacing={2.5}>
-            {error !== undefined && (
+            {error !== undefined && !error.hasFieldErrors && (
               <Alert severity={error.isPermissionDenied ? "warning" : "error"} role="alert">
                 {error.message}
               </Alert>
@@ -211,7 +213,7 @@ function CollectDialog({
               {reservation.itemReference} — {reservation.itemName}.{" "}
               {formatQuantity(reservation.quantityOutstanding)} {reservation.unit} outstanding.
             </Typography>
-            {error !== undefined && (
+            {error !== undefined && !error.hasFieldErrors && (
               <Alert severity={error.isPermissionDenied ? "warning" : "error"} role="alert">
                 {error.message}
               </Alert>
@@ -304,7 +306,7 @@ function ReleaseDialog({
               Gives back the {formatQuantity(reservation.quantityOutstanding)} {reservation.unit}{" "}
               that has not been collected. Anything already collected stays at the job site.
             </Typography>
-            {error !== undefined && (
+            {error !== undefined && !error.hasFieldErrors && (
               <Alert severity={error.isPermissionDenied ? "warning" : "error"} role="alert">
                 {error.message}
               </Alert>
@@ -461,6 +463,7 @@ export function JobDetailPage(): ReactElement {
   const [collecting, setCollecting] = useState<ReservationView | null>(null);
   const [releasing, setReleasing] = useState<ReservationView | null>(null);
   const [closing, setClosing] = useState(false);
+  const [confirmingClose, setConfirmingClose] = useState(false);
   const [closeError, setCloseError] = useState<ApiError | undefined>(undefined);
 
   const load = useCallback((signal: AbortSignal) => api.getJob(jobId, signal), [api, jobId]);
@@ -473,7 +476,10 @@ export function JobDetailPage(): ReactElement {
 
     void api
       .closeJob(jobId)
-      .then(() => job.reload())
+      .then(() => {
+        setConfirmingClose(false);
+        return job.reload();
+      })
       .catch((caught: unknown) => setCloseError(asApiError(caught)))
       .finally(() => setClosing(false));
   };
@@ -511,7 +517,7 @@ export function JobDetailPage(): ReactElement {
                   <Button
                     variant="outlined"
                     color="warning"
-                    onClick={handleClose}
+                    onClick={() => setConfirmingClose(true)}
                     disabled={closing}
                   >
                     {closing ? "Closing…" : "Close job"}
@@ -570,7 +576,7 @@ export function JobDetailPage(): ReactElement {
                         <TableCell align="right">Collected</TableCell>
                         <TableCell align="right">Outstanding</TableCell>
                         <TableCell>Status</TableCell>
-                        <TableCell>Raised by</TableCell>
+                        <TableCell>Reserved by</TableCell>
                         <TableCell align="right" />
                       </TableRow>
                     </TableHead>
@@ -589,14 +595,19 @@ export function JobDetailPage(): ReactElement {
                               {reservation.itemName}
                             </Typography>
                           </TableCell>
+                          {/*
+                           * With the unit, because "127 · 50.8 · 76.2" on its
+                           * own does not say whether those are metres or items,
+                           * and the reservation has always carried it.
+                           */}
                           <TableCell align="right">
-                            {formatQuantity(reservation.quantityReserved)}
+                            {formatQuantity(reservation.quantityReserved)} {reservation.unit}
                           </TableCell>
                           <TableCell align="right">
-                            {formatQuantity(reservation.quantityCollected)}
+                            {formatQuantity(reservation.quantityCollected)} {reservation.unit}
                           </TableCell>
                           <TableCell align="right" sx={{ fontWeight: 750 }}>
-                            {formatQuantity(reservation.quantityOutstanding)}
+                            {formatQuantity(reservation.quantityOutstanding)} {reservation.unit}
                           </TableCell>
                           <TableCell>
                             <Chip
@@ -659,7 +670,10 @@ export function JobDetailPage(): ReactElement {
                       {data.jobSiteStock.map((balance) => (
                         <TableRow key={`${balance.locationId}-${balance.locationName}`}>
                           <TableCell>{balance.locationName}</TableCell>
-                          <TableCell align="right">{formatQuantity(balance.quantity)}</TableCell>
+                          <TableCell align="right">
+                            {formatQuantity(balance.quantity)}
+                            {balance.unit === undefined ? "" : ` ${balance.unit}`}
+                          </TableCell>
                         </TableRow>
                       ))}
                     </TableBody>
@@ -696,11 +710,15 @@ export function JobDetailPage(): ReactElement {
                             {formatDateTime(transaction.occurredAt)}
                           </TableCell>
                           <TableCell>
-                            <Chip label={transaction.kind} size="small" variant="outlined" />
+                            <Chip
+                              label={transactionKindLabels[transaction.kind]}
+                              size="small"
+                              variant="outlined"
+                            />
                           </TableCell>
                           <TableCell>{transaction.itemReference}</TableCell>
                           <TableCell align="right">
-                            {formatQuantity(transaction.quantity)}
+                            {formatQuantity(transaction.quantity)} {transaction.unit}
                           </TableCell>
                           <TableCell>{transaction.actorName}</TableCell>
                         </TableRow>
@@ -729,6 +747,41 @@ export function JobDetailPage(): ReactElement {
               onDone={job.reload}
             />
           )}
+          {/*
+           * Releasing one reservation asks for a written reason; closing the job
+           * releases every one of them at once. The larger act was the one with
+           * no question attached, so it gets asked here — with the count, so the
+           * consequence is a number rather than a warning.
+           */}
+          <Dialog
+            open={confirmingClose}
+            onClose={() => setConfirmingClose(false)}
+            fullWidth
+            maxWidth="xs"
+          >
+            <DialogTitle>Close {data.number}?</DialogTitle>
+            <DialogContent>
+              <DialogContentText>
+                {openReservations.length === 0
+                  ? "Nothing is still reserved against this job."
+                  : `This releases ${String(openReservations.length)} uncollected reservation${
+                      openReservations.length === 1 ? "" : "s"
+                    } and gives that stock back to stores.`}
+                {data.jobSiteStock.length > 0 &&
+                  ` The ${String(data.jobSiteStock.length)} item${
+                    data.jobSiteStock.length === 1 ? "" : "s"
+                  } already collected stay at the job site.`}
+              </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={() => setConfirmingClose(false)} disabled={closing}>
+                Cancel
+              </Button>
+              <Button variant="contained" color="warning" onClick={handleClose} disabled={closing}>
+                {closing ? "Closing…" : "Close job"}
+              </Button>
+            </DialogActions>
+          </Dialog>
         </>
       )}
     </Box>

--- a/apps/web/src/pages/JobsPage.tsx
+++ b/apps/web/src/pages/JobsPage.tsx
@@ -79,7 +79,7 @@ function CreateJobDialog({ onClose }: { readonly onClose: () => void }): ReactEl
       <form onSubmit={handleSubmit} noValidate>
         <DialogContent dividers>
           <Stack spacing={2.5}>
-            {error !== undefined && (
+            {error !== undefined && !error.hasFieldErrors && (
               <Alert severity={error.isPermissionDenied ? "warning" : "error"} role="alert">
                 {error.message}
               </Alert>

--- a/apps/web/src/pages/LocationsPage.tsx
+++ b/apps/web/src/pages/LocationsPage.tsx
@@ -32,7 +32,7 @@ import type {
 
 import { ApiError } from "../api/ApiClient";
 import { useApi, useResource } from "../api/ApiContext";
-import { useAuth } from "../auth/AuthContext";
+import { useCapability } from "../auth/useCapability";
 import { useDebouncedValue } from "../hooks/use-debounced-value";
 import { mapBorder } from "./locations/constants";
 import {
@@ -57,8 +57,12 @@ const SEARCH_DEBOUNCE_MS = 250;
  */
 export function LocationsPage(): ReactElement {
   const api = useApi();
-  const { user } = useAuth();
-  const canEdit = user?.role === "Admin";
+  /*
+   * Editing the hierarchy and the map is one capability, resolved through the
+   * shared role map rather than a role name, so a change to ROLE_CAPABILITIES
+   * carries this screen with it. The server checks the same capability again.
+   */
+  const canEdit = useCapability("manageLocations");
   const [buildingId, setBuildingId] = useState<string | null>(null);
   const [editor, dispatch] = useReducer(editorReducer, initialEditor);
   const [query, setQuery] = useState("");
@@ -460,24 +464,39 @@ export function LocationsPage(): ReactElement {
                 ))}
               </Select>
             </FormControl>
-            <Button
-              variant="outlined"
-              size="small"
-              startIcon={<AddRounded />}
-              onClick={() => document.getElementById("new-location-code")?.focus()}
-              disabled={!canEdit || hierarchyRoot === null}
-            >
-              Add building
-            </Button>
-            <Button
-              variant="outlined"
-              size="small"
-              startIcon={<MapRounded />}
-              onClick={() => svgRef.current?.focus()}
-              disabled={draft === null}
-            >
-              Edit map
-            </Button>
+            {/*
+             * Both of these only exist for a role that can actually change
+             * something. A role that cannot gets no button at all rather than a
+             * greyed stub or — worse — a live one that quietly does nothing:
+             * the navigation already hides whole sections by role, and this is
+             * the same idea one level down.
+             */}
+            {canEdit && (
+              <>
+                <Tooltip title="Jumps to the new-location form below the hierarchy">
+                  <span>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      startIcon={<AddRounded />}
+                      onClick={() => document.getElementById("new-location-code")?.focus()}
+                      disabled={hierarchyRoot === null}
+                    >
+                      Add building
+                    </Button>
+                  </span>
+                </Tooltip>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  startIcon={<MapRounded />}
+                  onClick={() => svgRef.current?.focus()}
+                  disabled={draft === null}
+                >
+                  Edit map
+                </Button>
+              </>
+            )}
           </Stack>
         </Stack>
         {(conflict || saveMessage !== null) && (

--- a/apps/web/src/pages/LocationsPage.tsx
+++ b/apps/web/src/pages/LocationsPage.tsx
@@ -4,9 +4,7 @@ import {
   Alert,
   Box,
   Button,
-  Chip,
   FormControl,
-  IconButton,
   InputLabel,
   MenuItem,
   Select,
@@ -422,26 +420,28 @@ export function LocationsPage(): ReactElement {
           alignItems={{ md: "center" }}
           spacing={1.5}
         >
+          {/*
+           * The building said once. This header used to name it four times over
+           * — breadcrumb, heading, a "Building" chip, its code, and again inside
+           * the selector — which is a lot of furniture for one fact. The
+           * breadcrumb marks the section, the heading names the building, the
+           * caption carries its code, and the selector is how you change it.
+           */}
           <Box sx={{ minWidth: 0 }}>
             <Typography
               variant="overline"
               color="text.secondary"
               sx={{ display: "block", letterSpacing: "0.08em" }}
             >
-              Locations / {selectedBuilding?.name ?? "Building"}
+              Locations
             </Typography>
-            <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
-              <Typography
-                variant="h1"
-                component="h1"
-                sx={{ fontSize: { xs: "1.6rem", sm: "2rem" }, lineHeight: 1.15 }}
-              >
-                {selectedBuilding?.name ?? "Locations"}
-              </Typography>
-              {selectedBuilding !== undefined && (
-                <Chip label="Building" size="small" variant="outlined" />
-              )}
-            </Stack>
+            <Typography
+              variant="h1"
+              component="h1"
+              sx={{ fontSize: { xs: "1.6rem", sm: "2rem" }, lineHeight: 1.15 }}
+            >
+              {selectedBuilding?.name ?? "Locations"}
+            </Typography>
             <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 700 }}>
               {selectedBuilding?.code ?? "Select a building to open its map"}
             </Typography>
@@ -631,33 +631,36 @@ export function LocationsPage(): ReactElement {
               bgcolor: "#FBFCFE",
             }}
           >
+            {/*
+             * One control, reading the normal way round. This was an icon
+             * button above a second button with its text turned on its side —
+             * two ways to do the same thing, and the label unreadable without
+             * tilting your head. Someone who has just clicked a region needs to
+             * see at a glance where its details went.
+             */}
             <Tooltip title="Open region details" placement="left">
-              <IconButton
+              <Button
+                variant="text"
                 size="small"
                 aria-label="Open region details"
                 onClick={() => {
                   setInspectorOpen(true);
                 }}
+                sx={{
+                  minWidth: 0,
+                  flexDirection: "column",
+                  gap: 0.25,
+                  px: 0.5,
+                  py: 1,
+                  fontSize: "0.7rem",
+                  fontWeight: 800,
+                  lineHeight: 1.2,
+                }}
               >
                 <MapRounded fontSize="small" />
-              </IconButton>
+                Details
+              </Button>
             </Tooltip>
-            <Button
-              variant="text"
-              size="small"
-              aria-label="Open region details"
-              onClick={() => {
-                setInspectorOpen(true);
-              }}
-              sx={{
-                writingMode: "vertical-rl",
-                transform: "rotate(180deg)",
-                fontSize: "0.75rem",
-                fontWeight: 800,
-              }}
-            >
-              Details
-            </Button>
           </Box>
         )}
       </Box>

--- a/apps/web/src/pages/Screens.test.tsx
+++ b/apps/web/src/pages/Screens.test.tsx
@@ -123,7 +123,9 @@ describe("dashboard", () => {
 
     const table = await screen.findByRole("table", { name: "Inventory" });
 
-    expect(within(table).getByRole("columnheader", { name: "For you" })).toBeInTheDocument();
+    expect(
+      within(table).getByRole("columnheader", { name: "Reserved for you" }),
+    ).toBeInTheDocument();
     const row = within(table).getByText("M6 × 30 mm zinc-plated hex bolt").closest("tr");
     expect(within(row as HTMLElement).getByText("30")).toBeInTheDocument();
   });
@@ -177,10 +179,17 @@ describe("item detail", () => {
 
     await screen.findByRole("heading", { name: testItemDetail.name });
 
-    expect(screen.getByText("420 ea")).toBeInTheDocument();
-    expect(screen.getByText("400")).toBeInTheDocument();
-    expect(screen.getByText("20")).toBeInTheDocument();
-    expect(screen.getByText("350")).toBeInTheDocument();
+    /*
+     * Read per tile rather than across the page: every tile now carries the
+     * unit, so a bare "400 ea" also matches the location holding that much.
+     */
+    const figure = (label: string): string =>
+      within(screen.getByRole("group", { name: label })).getByRole("paragraph").textContent;
+
+    expect(figure("On hand")).toBe("420 ea");
+    expect(figure("In stores")).toBe("400 ea");
+    expect(figure("At job sites")).toBe("20 ea");
+    expect(figure("Available")).toBe("350 ea");
   });
 
   it("renders a QR code labelled with the item reference", async () => {
@@ -246,7 +255,7 @@ describe("item detail", () => {
 
     const dialog = await screen.findByRole("dialog");
     expect(within(dialog).getByLabelText(/Reason/u)).toBeRequired();
-    expect(within(dialog).getByLabelText(/Counted quantity/u)).toBeInTheDocument();
+    expect(within(dialog).getByLabelText(/Total counted/u)).toBeInTheDocument();
   });
 });
 
@@ -260,9 +269,9 @@ describe("job detail", () => {
     const table = await screen.findByRole("table", { name: "Reservations" });
     const row = within(table).getByText("ITM-0001").closest("tr") as HTMLElement;
 
-    expect(within(row).getByText("50")).toBeInTheDocument();
-    expect(within(row).getByText("20")).toBeInTheDocument();
-    expect(within(row).getByText("30")).toBeInTheDocument();
+    expect(within(row).getByText("50 ea")).toBeInTheDocument();
+    expect(within(row).getByText("20 ea")).toBeInTheDocument();
+    expect(within(row).getByText("30 ea")).toBeInTheDocument();
   });
 
   it("warns that closing leaves job-site stock where it is", async () => {
@@ -358,7 +367,7 @@ describe("stock requests", () => {
     expect(screen.getByText(/Sam Field/u)).toBeInTheDocument();
     expect(screen.getByText(/Running short on site/u)).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Reject" }));
+    await user.click(screen.getByRole("button", { name: "Turn down" }));
 
     const dialog = await screen.findByRole("dialog");
     /* A refusal has to say why, so the person who asked is not left guessing. */

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -34,19 +34,10 @@ import {
   formatQuantity,
   LoadingRows,
   PageHeader,
+  transactionKindLabels,
 } from "../components/DataStates";
 
 const PAGE_SIZE = 50;
-
-const transactionKindLabels: Readonly<Record<TransactionKind, string>> = {
-  Receive: "Receive",
-  Issue: "Take out",
-  Transfer: "Transfer",
-  Adjust: "Adjust",
-  Reserve: "Reserve",
-  Collect: "Collect",
-  Release: "Release",
-};
 
 /** Converts the human-facing UK date into an unambiguous UTC timestamp. */
 function parseUkDate(value: string, endOfDay = false): string | undefined {
@@ -203,8 +194,8 @@ export function TransactionsPage(): ReactElement {
         title={seesEveryone ? "Every change, and who made it" : "Your activity"}
         description={
           seesEveryone
-            ? "An append-only record. Mistakes are corrected with a new adjustment, never by editing history."
-            : "Everything you have received, taken out, collected or reserved. An append-only record — nothing here can be edited."
+            ? "Nothing here can be edited or deleted. A mistake is put right with a new adjustment, so the original stays visible alongside the correction."
+            : "Everything you have received, taken out, collected or reserved. Nothing here can be edited or deleted."
         }
         actions={
           <Button variant="outlined" startIcon={<FileDownloadRounded />} onClick={handleExport}>
@@ -215,10 +206,10 @@ export function TransactionsPage(): ReactElement {
 
       <Paper variant="outlined" sx={{ mb: 2.5, p: { xs: 1.5, sm: 2 } }}>
         <Typography variant="subtitle2" sx={{ mb: 1.25, fontWeight: 800 }}>
-          Filter the When column
+          Narrow the list
         </Typography>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
-          Search by the item reference, colloquial name, barcode, or part number. Dates use
+          Search by the item code, name, barcode, or part number. Dates use
           <strong> dd/mm/yyyy</strong>.
         </Typography>
         <Stack direction={{ xs: "column", md: "row" }} spacing={1.5}>

--- a/apps/web/src/pages/UserDetailPage.tsx
+++ b/apps/web/src/pages/UserDetailPage.tsx
@@ -92,7 +92,7 @@ function DetailsForm({
       <Divider />
       <Box component="form" onSubmit={handleSave} sx={{ px: 2.5, py: 2.5 }} noValidate>
         <Stack spacing={2.5} sx={{ maxWidth: 480 }}>
-          {error !== undefined && (
+          {error !== undefined && !error.hasFieldErrors && (
             <Alert severity={error.isPermissionDenied ? "warning" : "error"} role="alert">
               {error.message}
             </Alert>

--- a/apps/web/src/pages/UsersPage.tsx
+++ b/apps/web/src/pages/UsersPage.tsx
@@ -8,7 +8,9 @@ import {
   Dialog,
   DialogActions,
   DialogContent,
+  DialogContentText,
   DialogTitle,
+  Divider,
   InputAdornment,
   Link,
   MenuItem,
@@ -24,7 +26,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import { userRoles, type UserRole } from "@stockcontrol/contracts";
+import { userRoles, type UserRole, type UserView } from "@stockcontrol/contracts";
 import { useCallback, useState, type FormEvent, type ReactElement } from "react";
 import { Link as RouterLink } from "react-router-dom";
 
@@ -82,7 +84,7 @@ function CreateUserDialog({
       <form onSubmit={handleSubmit} noValidate>
         <DialogContent dividers>
           <Stack spacing={2.5}>
-            {error !== undefined && (
+            {error !== undefined && !error.hasFieldErrors && (
               <Alert severity={error.isPermissionDenied ? "warning" : "error"} role="alert">
                 {error.message}
               </Alert>
@@ -152,6 +154,11 @@ function CreateUserDialog({
   );
 }
 
+/** A change to somebody's access, held until it has been confirmed. */
+type PendingChange =
+  | { readonly kind: "role"; readonly user: UserView; readonly role: UserRole }
+  | { readonly kind: "active"; readonly user: UserView; readonly isActive: boolean };
+
 export function UsersPage(): ReactElement {
   const api = useApi();
   const { user: signedInUser } = useAuth();
@@ -159,6 +166,7 @@ export function UsersPage(): ReactElement {
   const [search, setSearch] = useState("");
   const [actionError, setActionError] = useState<ApiError | undefined>(undefined);
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [pending, setPending] = useState<PendingChange | null>(null);
 
   const load = useCallback((signal: AbortSignal) => api.listUsers(signal), [api]);
   const users = useResource(load);
@@ -183,10 +191,40 @@ export function UsersPage(): ReactElement {
 
     void api
       .updateUser(id, changes)
-      .then(() => users.reload())
+      .then(() => {
+        setPending(null);
+        return users.reload();
+      })
       .catch((caught: unknown) => setActionError(asApiError(caught)))
       .finally(() => setBusyId(null));
   };
+
+  /*
+   * Both of these controls change what somebody can do the instant they move,
+   * and disabling an account also ends whatever that person is in the middle
+   * of. Ask first, and say plainly what will happen — an accidental brush of a
+   * dropdown should not be able to demote a colleague.
+   */
+  const confirmation =
+    pending === null
+      ? null
+      : pending.kind === "role"
+        ? {
+            title: `Change ${pending.user.displayName} to ${pending.role}?`,
+            body: `They currently sign in as ${pending.user.role}. The new role applies to their next request — anything already open in their browser follows it immediately.`,
+            action: "Change role",
+            run: () => update(pending.user.id, { role: pending.role }),
+          }
+        : {
+            title: pending.isActive
+              ? `Turn ${pending.user.displayName}'s access back on?`
+              : `Disable ${pending.user.displayName}?`,
+            body: pending.isActive
+              ? "They will be able to sign in again straight away."
+              : "They are signed out immediately and cannot sign back in. Their history stays in the log.",
+            action: pending.isActive ? "Enable" : "Disable",
+            run: () => update(pending.user.id, { isActive: pending.isActive }),
+          };
 
   return (
     <Box>
@@ -244,6 +282,15 @@ export function UsersPage(): ReactElement {
 
       {rows.length > 0 && (
         <Paper variant="outlined">
+          {/*
+           * Above the table, not below it: this explains what the controls in
+           * the rows do, and an explanation read after the fact is no use.
+           */}
+          <Typography variant="body2" color="text.secondary" sx={{ px: 2, py: 1.5 }}>
+            Open a name to edit their details or review what they have done. Disabling someone ends
+            their active sessions immediately. You cannot change your own role or disable yourself.
+          </Typography>
+          <Divider />
           <TableContainer>
             <Table aria-label="Users">
               <TableHead>
@@ -281,7 +328,11 @@ export function UsersPage(): ReactElement {
                           size="small"
                           value={row.role}
                           onChange={(event) =>
-                            update(row.id, { role: event.target.value as UserRole })
+                            setPending({
+                              kind: "role",
+                              user: row,
+                              role: event.target.value as UserRole,
+                            })
                           }
                           disabled={isSelf || busyId === row.id}
                           aria-label={`Role for ${row.displayName}`}
@@ -300,7 +351,13 @@ export function UsersPage(): ReactElement {
                       <TableCell align="right">
                         <Switch
                           checked={row.isActive}
-                          onChange={(event) => update(row.id, { isActive: event.target.checked })}
+                          onChange={(event) =>
+                            setPending({
+                              kind: "active",
+                              user: row,
+                              isActive: event.target.checked,
+                            })
+                          }
                           disabled={isSelf || busyId === row.id}
                           slotProps={{ input: { "aria-label": `Active: ${row.displayName}` } }}
                         />
@@ -311,11 +368,24 @@ export function UsersPage(): ReactElement {
               </TableBody>
             </Table>
           </TableContainer>
-          <Typography variant="body2" color="text.secondary" sx={{ px: 2, py: 1.5 }}>
-            Open a name to edit their details or review what they have done. Disabling someone ends
-            their active sessions immediately. You cannot change your own role or disable yourself.
-          </Typography>
         </Paper>
+      )}
+
+      {confirmation !== null && (
+        <Dialog open onClose={() => setPending(null)} fullWidth maxWidth="xs">
+          <DialogTitle>{confirmation.title}</DialogTitle>
+          <DialogContent>
+            <DialogContentText>{confirmation.body}</DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setPending(null)} disabled={busyId !== null}>
+              Cancel
+            </Button>
+            <Button variant="contained" onClick={confirmation.run} disabled={busyId !== null}>
+              {confirmation.action}
+            </Button>
+          </DialogActions>
+        </Dialog>
       )}
 
       {creating && <CreateUserDialog onClose={() => setCreating(false)} onDone={users.reload} />}

--- a/apps/web/src/pages/locations/HierarchyTree.tsx
+++ b/apps/web/src/pages/locations/HierarchyTree.tsx
@@ -129,6 +129,7 @@ const HierarchyTreeItem = memo(function HierarchyTreeItem({
           secondary={node.code}
           sx={textSx}
           slotProps={treeItemSlotProps}
+          title={`${node.name} · ${node.code}`}
         />
       </TreeRow>
     </TreeItem>

--- a/apps/web/src/pages/locations/MapRegionShape.tsx
+++ b/apps/web/src/pages/locations/MapRegionShape.tsx
@@ -17,27 +17,51 @@ const TWO_LINE_MIN_HEIGHT = 9;
  * on every frame of a drag.
  */
 const CHARACTER_WIDTH_RATIO = 0.55;
+/**
+ * How much of the available slice a line may fill. The rest is breathing room:
+ * text that ends exactly on the edge reads as though it has been cut off by it,
+ * and the character-width estimate above is an estimate, so the margin also
+ * absorbs the cases where it runs a little narrow.
+ */
+const FILL_RATIO = 0.86;
+
+interface LabelSpace {
+  readonly width: number;
+  readonly height: number;
+  readonly centreX: number;
+}
 
 /**
- * How much room a label really has, and how tall the shape is.
+ * Where a label fits, and how much room it has there.
  *
- * For a polygon the answer is the width of the shape *at the line the label
- * sits on*, not the width of its bounding box: a trapezoid that tapers towards
- * the bottom is far narrower where the text lands than at its widest point, and
- * measuring the box let the label run out over the edge.
+ * For a polygon the answer comes from the slice of the shape *on the line the
+ * label sits on*, not from its bounding box: a trapezoid that tapers towards
+ * the bottom is far narrower where the text lands than at its widest point.
+ *
+ * Both the width and the centre have to come from that slice. Measuring the
+ * width there but still centring on the polygon's centroid puts text that fits
+ * in the wrong place, and it hangs over one edge anyway — the centroid of a
+ * tapering shape is not the middle of any particular line across it.
  */
-function labelSpace(
-  geometry: MapRegionView["geometry"],
-  labelY: number,
-): { readonly width: number; readonly height: number } {
+function labelSpace(geometry: MapRegionView["geometry"], labelY: number): LabelSpace {
   if (geometry.kind === "Rectangle") {
-    return { width: geometry.width, height: geometry.height };
+    return {
+      width: geometry.width,
+      height: geometry.height,
+      centreX: geometry.x + geometry.width / 2,
+    };
   }
 
+  const xs = geometry.points.map((point) => point.x);
   const ys = geometry.points.map((point) => point.y);
   const height = Math.max(...ys) - Math.min(...ys);
+  const fallback = {
+    width: Math.max(...xs) - Math.min(...xs),
+    height,
+    centreX: (Math.max(...xs) + Math.min(...xs)) / 2,
+  };
 
-  /* Where each edge crosses the label's line, giving the span available there. */
+  /* Where each edge crosses the label's line, giving the slice available there. */
   const crossings: number[] = [];
   for (let index = 0; index < geometry.points.length; index += 1) {
     const start = geometry.points[index];
@@ -49,17 +73,29 @@ function labelSpace(
     crossings.push(start.x + ((labelY - start.y) / (end.y - start.y)) * (end.x - start.x));
   }
 
-  if (crossings.length < 2) {
-    const xs = geometry.points.map((point) => point.x);
-    return { width: Math.max(...xs) - Math.min(...xs), height };
-  }
+  if (crossings.length < 2) return fallback;
 
-  return { width: Math.max(...crossings) - Math.min(...crossings), height };
+  const left = Math.min(...crossings);
+  const right = Math.max(...crossings);
+
+  return { width: right - left, height, centreX: (left + right) / 2 };
+}
+
+/** The part of two slices that both share, so text placed there sits in both. */
+function overlap(a: LabelSpace, b: LabelSpace): LabelSpace {
+  const left = Math.max(a.centreX - a.width / 2, b.centreX - b.width / 2);
+  const right = Math.min(a.centreX + a.width / 2, b.centreX + b.width / 2);
+
+  return {
+    width: Math.max(0, right - left),
+    height: a.height,
+    centreX: (left + right) / 2,
+  };
 }
 
 /** Cuts `text` to what fits `width`, ending in an ellipsis when it had to. */
 function truncateToWidth(text: string, width: number, fontSize: number): string {
-  const fits = Math.floor((width * 0.92) / (fontSize * CHARACTER_WIDTH_RATIO));
+  const fits = Math.floor((width * FILL_RATIO) / (fontSize * CHARACTER_WIDTH_RATIO));
 
   if (fits <= 1) return "";
   return text.length <= fits ? text : `${text.slice(0, fits - 1).trimEnd()}…`;
@@ -119,16 +155,29 @@ export const MapRegionShape = memo(function MapRegionShape({
    * a second line at all. The full text stays in the group's aria-label, and
    * the inspector shows it in full, so nothing is actually lost.
    */
-  const space = labelSpace(geometry, normalizedCenter.y);
+  const twoLines =
+    labelSpace(geometry, normalizedCenter.y).height * MAP_UNITS >= TWO_LINE_MIN_HEIGHT;
+  /*
+   * Measured on both baselines and narrowed to where they agree. The two lines
+   * share an x, so the room they have is the room the *lower* one has — on a
+   * shape that tapers, the summary sits four units further down and the walls
+   * have closed in by then. Taking the overlap keeps both inside.
+   */
+  const nameY = normalizedCenter.y - (twoLines ? 1.5 / MAP_UNITS : 0);
+  const summaryY = nameY + 4 / MAP_UNITS;
+  const space = twoLines
+    ? overlap(labelSpace(geometry, nameY), labelSpace(geometry, summaryY))
+    : labelSpace(geometry, nameY);
+
+  const labelX = space.centreX * MAP_UNITS;
   const nameLine = truncateToWidth(
     `${region.displayName}${locationCode === undefined ? "" : ` · ${locationCode}`}`,
     space.width * MAP_UNITS,
     NAME_FONT_SIZE,
   );
-  const summaryLine =
-    space.height * MAP_UNITS < TWO_LINE_MIN_HEIGHT
-      ? undefined
-      : truncateToWidth(`${itemSummary}${moreItems}`, space.width * MAP_UNITS, SUMMARY_FONT_SIZE);
+  const summaryLine = !twoLines
+    ? undefined
+    : truncateToWidth(`${itemSummary}${moreItems}`, space.width * MAP_UNITS, SUMMARY_FONT_SIZE);
   const shapeProps = {
     "data-region-id": region.id,
     fill: region.stock.colour,
@@ -160,8 +209,8 @@ export const MapRegionShape = memo(function MapRegionShape({
       )}
       {nameLine.length > 0 && (
         <text
-          x={normalizedCenter.x * MAP_UNITS}
-          y={normalizedCenter.y * MAP_UNITS - (summaryLine === undefined ? 0 : 1.5)}
+          x={labelX}
+          y={nameY * MAP_UNITS}
           textAnchor="middle"
           dominantBaseline="middle"
           pointerEvents="none"
@@ -169,14 +218,9 @@ export const MapRegionShape = memo(function MapRegionShape({
           fontSize={NAME_FONT_SIZE}
           fontWeight="700"
         >
-          <tspan x={normalizedCenter.x * MAP_UNITS}>{nameLine}</tspan>
+          <tspan x={labelX}>{nameLine}</tspan>
           {summaryLine !== undefined && summaryLine.length > 0 && (
-            <tspan
-              x={normalizedCenter.x * MAP_UNITS}
-              dy="4"
-              fontSize={SUMMARY_FONT_SIZE}
-              fontWeight="500"
-            >
+            <tspan x={labelX} dy="4" fontSize={SUMMARY_FONT_SIZE} fontWeight="500">
               {summaryLine}
             </tspan>
           )}

--- a/apps/web/src/pages/locations/MapRegionShape.tsx
+++ b/apps/web/src/pages/locations/MapRegionShape.tsx
@@ -6,6 +6,65 @@ import { selectionStroke, shapeStroke } from "./constants";
 import { MAP_UNITS, polylinePoints } from "./geometry";
 import type { LiveGeometryStore } from "./live-geometry-store";
 
+const NAME_FONT_SIZE = 2.8;
+const SUMMARY_FONT_SIZE = 2.2;
+/** Below this, a shape cannot show two lines without them spilling out of it. */
+const TWO_LINE_MIN_HEIGHT = 9;
+/**
+ * Rough advance width of one character as a fraction of the font size. The
+ * label is a plain sans-serif, so this is close enough to keep text inside its
+ * shape without measuring — and measuring would mean a layout read per region
+ * on every frame of a drag.
+ */
+const CHARACTER_WIDTH_RATIO = 0.55;
+
+/**
+ * How much room a label really has, and how tall the shape is.
+ *
+ * For a polygon the answer is the width of the shape *at the line the label
+ * sits on*, not the width of its bounding box: a trapezoid that tapers towards
+ * the bottom is far narrower where the text lands than at its widest point, and
+ * measuring the box let the label run out over the edge.
+ */
+function labelSpace(
+  geometry: MapRegionView["geometry"],
+  labelY: number,
+): { readonly width: number; readonly height: number } {
+  if (geometry.kind === "Rectangle") {
+    return { width: geometry.width, height: geometry.height };
+  }
+
+  const ys = geometry.points.map((point) => point.y);
+  const height = Math.max(...ys) - Math.min(...ys);
+
+  /* Where each edge crosses the label's line, giving the span available there. */
+  const crossings: number[] = [];
+  for (let index = 0; index < geometry.points.length; index += 1) {
+    const start = geometry.points[index];
+    const end = geometry.points[(index + 1) % geometry.points.length];
+    if (start === undefined || end === undefined) continue;
+    if (start.y === end.y) continue;
+    if (labelY < Math.min(start.y, end.y) || labelY > Math.max(start.y, end.y)) continue;
+
+    crossings.push(start.x + ((labelY - start.y) / (end.y - start.y)) * (end.x - start.x));
+  }
+
+  if (crossings.length < 2) {
+    const xs = geometry.points.map((point) => point.x);
+    return { width: Math.max(...xs) - Math.min(...xs), height };
+  }
+
+  return { width: Math.max(...crossings) - Math.min(...crossings), height };
+}
+
+/** Cuts `text` to what fits `width`, ending in an ellipsis when it had to. */
+function truncateToWidth(text: string, width: number, fontSize: number): string {
+  const fits = Math.floor((width * 0.92) / (fontSize * CHARACTER_WIDTH_RATIO));
+
+  if (fits <= 1) return "";
+  return text.length <= fits ? text : `${text.slice(0, fits - 1).trimEnd()}…`;
+}
+
 interface MapRegionShapeProps {
   readonly region: MapRegionView;
   readonly locationCode: string | undefined;
@@ -51,6 +110,25 @@ export const MapRegionShape = memo(function MapRegionShape({
           .join(", ");
   const moreItems =
     region.stock.items.length > 2 ? ` +${String(region.stock.items.length - 2)}` : "";
+
+  /*
+   * SVG text does not wrap and does not clip, so a name longer than its shape
+   * used to run out across the floor plan — white on a pale grid, unreadable,
+   * and overlapping whatever it crossed. Both lines are cut to what the shape
+   * can hold, and the item summary is dropped when the shape is too short for
+   * a second line at all. The full text stays in the group's aria-label, and
+   * the inspector shows it in full, so nothing is actually lost.
+   */
+  const space = labelSpace(geometry, normalizedCenter.y);
+  const nameLine = truncateToWidth(
+    `${region.displayName}${locationCode === undefined ? "" : ` · ${locationCode}`}`,
+    space.width * MAP_UNITS,
+    NAME_FONT_SIZE,
+  );
+  const summaryLine =
+    space.height * MAP_UNITS < TWO_LINE_MIN_HEIGHT
+      ? undefined
+      : truncateToWidth(`${itemSummary}${moreItems}`, space.width * MAP_UNITS, SUMMARY_FONT_SIZE);
   const shapeProps = {
     "data-region-id": region.id,
     fill: region.stock.colour,
@@ -80,24 +158,30 @@ export const MapRegionShape = memo(function MapRegionShape({
       ) : (
         <polygon {...shapeProps} points={polylinePoints(geometry.points)} />
       )}
-      <text
-        x={normalizedCenter.x * MAP_UNITS}
-        y={normalizedCenter.y * MAP_UNITS - 1.5}
-        textAnchor="middle"
-        dominantBaseline="middle"
-        pointerEvents="none"
-        fill="#FFFFFF"
-        fontSize="2.8"
-        fontWeight="700"
-      >
-        <tspan x={normalizedCenter.x * MAP_UNITS}>
-          {region.displayName}{locationCode === undefined ? "" : ` · ${locationCode}`}
-        </tspan>
-        <tspan x={normalizedCenter.x * MAP_UNITS} dy="4" fontSize="2.2" fontWeight="500">
-          {itemSummary}
-          {moreItems}
-        </tspan>
-      </text>
+      {nameLine.length > 0 && (
+        <text
+          x={normalizedCenter.x * MAP_UNITS}
+          y={normalizedCenter.y * MAP_UNITS - (summaryLine === undefined ? 0 : 1.5)}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          pointerEvents="none"
+          fill="#FFFFFF"
+          fontSize={NAME_FONT_SIZE}
+          fontWeight="700"
+        >
+          <tspan x={normalizedCenter.x * MAP_UNITS}>{nameLine}</tspan>
+          {summaryLine !== undefined && summaryLine.length > 0 && (
+            <tspan
+              x={normalizedCenter.x * MAP_UNITS}
+              dy="4"
+              fontSize={SUMMARY_FONT_SIZE}
+              fontWeight="500"
+            >
+              {summaryLine}
+            </tspan>
+          )}
+        </text>
+      )}
     </g>
   );
 });

--- a/apps/web/src/pages/locations/MapToolbar.tsx
+++ b/apps/web/src/pages/locations/MapToolbar.tsx
@@ -1,5 +1,6 @@
 import FitScreenRounded from "@mui/icons-material/FitScreenRounded";
 import GridOnRounded from "@mui/icons-material/GridOnRounded";
+import LockOutlined from "@mui/icons-material/LockOutlined";
 import LoginRounded from "@mui/icons-material/LoginRounded";
 import LogoutRounded from "@mui/icons-material/LogoutRounded";
 import PanToolRounded from "@mui/icons-material/PanToolRounded";
@@ -98,7 +99,26 @@ export const MapToolbar = memo(function MapToolbar({
               </ToggleButton>
             </ToggleButtonGroup>
           ) : (
-            <Chip size="small" label="View only" variant="outlined" />
+            /*
+             * A statement, not a control. As an outlined chip it wore the same
+             * pill shape as the toggle buttons beside it, and for a role that
+             * cannot edit it is the only thing left in this group — which made
+             * it look like the button you press to start editing. A lock and
+             * plain text cannot be mistaken for something to click.
+             */
+            <Tooltip title="Only an Admin can change this map">
+              <Stack
+                direction="row"
+                spacing={0.5}
+                alignItems="center"
+                sx={{ px: 0.75, color: "text.secondary" }}
+              >
+                <LockOutlined sx={{ fontSize: 16 }} />
+                <Typography variant="caption" sx={{ fontWeight: 700 }}>
+                  View only
+                </Typography>
+              </Stack>
+            </Tooltip>
           )}
         </Box>
         {canEdit && (

--- a/apps/web/src/pages/locations/MapWorkspace.tsx
+++ b/apps/web/src/pages/locations/MapWorkspace.tsx
@@ -103,18 +103,25 @@ export function MapWorkspace({
         onRevert={onRevert}
         onUploadClick={openFilePicker}
       />
-      <input
-        ref={fileInput}
-        hidden
-        type="file"
-        accept="image/png,image/jpeg"
-        aria-label="Upload floor plan"
-        onChange={(event) => {
-          const file = event.target.files?.[0];
-          event.target.value = "";
-          if (file !== undefined) onUploadFile(file);
-        }}
-      />
+      {/*
+       * Mounted only for a role that may upload. Being `hidden` keeps it out of
+       * sight either way, but a control nobody is allowed to use should not be
+       * in the tree at all — the guard here matches the button that opens it.
+       */}
+      {canEdit && (
+        <input
+          ref={fileInput}
+          hidden
+          type="file"
+          accept="image/png,image/jpeg"
+          aria-label="Upload floor plan"
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            event.target.value = "";
+            if (file !== undefined) onUploadFile(file);
+          }}
+        />
+      )}
       {map === null ? (
         <Box sx={emptyCanvasSx}>
           {canCreateMap ? (

--- a/apps/web/src/pages/locations/constants.ts
+++ b/apps/web/src/pages/locations/constants.ts
@@ -15,8 +15,13 @@ export const gridLine = "#DFE5EE";
 export const selectionStroke = "#071B3A";
 export const shapeStroke = "#FFFFFF";
 
+/*
+ * Only the four states the server can actually produce. It emits Available,
+ * LowStock, OutOfStock and Archived and nothing else, so a fifth swatch here
+ * described a colour no region ever wears — and "Full" sitting beside
+ * "Available" implied a distinction between them that does not exist.
+ */
 export const statusLegend = [
-  { colour: "#1565C0", label: "Full" },
   { colour: "#2E7D32", label: "Available" },
   { colour: "#ED6C02", label: "Low stock" },
   { colour: "#D32F2F", label: "Out of stock" },
@@ -78,11 +83,23 @@ export const emptyCanvasSx: SxProps<Theme> = {
 };
 
 export const treeItemSlotProps = {
+  /*
+   * Wraps to two lines rather than cutting at one. Sibling bays share a long
+   * prefix — "Main store, aisle A, bay 1/2/3" — so a single truncated line
+   * rendered three different shelves as the identical "Main store, aisle A…"
+   * and left the code underneath as the only thing telling them apart.
+   */
   primary: {
-    noWrap: true,
     fontSize: "0.84rem",
     fontWeight: 700,
     color: "#17243B",
+    sx: {
+      display: "-webkit-box",
+      WebkitBoxOrient: "vertical",
+      WebkitLineClamp: 2,
+      overflow: "hidden",
+      lineHeight: 1.3,
+    },
   },
   secondary: {
     noWrap: true,

--- a/packages/contracts/src/inventory.ts
+++ b/packages/contracts/src/inventory.ts
@@ -28,6 +28,12 @@ export interface LocationBalanceView {
   readonly locationName: string;
   readonly kind: LocationKind;
   readonly quantity: string;
+  /**
+   * Present only where the rows span more than one item, as they do at a job
+   * site. An item's own balances all share that item's unit, which the page
+   * already has, so repeating it there would be noise.
+   */
+  readonly unit?: string;
 }
 
 export interface ItemSummaryView {


### PR DESCRIPTION
A walkthrough of every screen as all three roles, read from the point of view
of someone who knows the trade but not stock systems, turned up four kinds of
problem. Each is fixed here.

Controls a role could see but never use. On Locations, "Edit map" was enabled
for Engineer and Office and merely focused the canvas — no tool appeared, the
toolbar still read "View only", nothing said why — and "Add building" was a
permanently greyed stub. Both are now behind the editing capability, so a role
that cannot edit sees no editing controls at all. Every other screen was
already gated correctly, confirmed by diffing the visible controls per role
against ROLE_CAPABILITIES.

One thing with two names. The stored kind is Issue and every button says "Take
out", so the Overview, item and job histories read "Issue" while the same event
on Transactions read "Take out". The label map moves to DataStates and all four
screens use it. Likewise the button that opened "Turn down request" said
"Reject", "Item ID" was "item reference" elsewhere, and "threshold" is now
"minimum".

Safeguards that were the wrong way round. Releasing one reservation asked for a
written reason; closing the job released every one of them on a single click.
Closing now confirms, with the count. Changing a role and disabling an account
applied the instant the control moved, with the explanation printed below the
table where it was read too late — both confirm, and the explanation moved
above.

Figures without their unit, and words that explain nothing. Four of the five
tiles on an item omitted the unit the fifth showed, and a reservation read
"127 · 50.8 · 76.2" with nothing saying metres or items. Every dialog opened
with a red "Validation failed" above field messages that already said "Enter a
location." The adjust dialog never said its number replaces the count rather
than adding to it — the one place this could lose real stock.

Also: map region labels were centred with no width limit, so long names ran out
of their shape across the floor plan in white-on-white; they now truncate to
the width the shape actually offers at that line. The legend advertised a
"Full" colour the server cannot produce. The scan button covered the last row
of long tables.

LocationBalanceView gains an optional unit, populated only where rows span more
than one item, as they do at a job site.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Rm41aZJV511bA8yHigi8ey