### PR TITLE
ci: add CodeQL and repository security gates

### DIFF
--- a/.github/SECURITY_CONFIGURATION.md
+++ b/.github/SECURITY_CONFIGURATION.md
@@ -2,6 +2,10 @@
 
 The workflows in this repository provide enforceable checks, but repository settings must also be configured in GitHub. Treat this file as the configuration checklist for `Settings`.
 
+## Promotion sequence
+
+All feature, maintenance, dependency, and security changes must target `develop`. After those changes have passed CI and been exercised in staging, open a separate pull request from `develop` to `main` for the production release. The `promotion-policy` workflow enforces this source branch on pull requests into `main`.
+
 ## Code security
 
 Enable all features available for the repository:

--- a/.github/SECURITY_CONFIGURATION.md
+++ b/.github/SECURITY_CONFIGURATION.md
@@ -1,0 +1,58 @@
+# GitHub security and branch configuration
+
+The workflows in this repository provide enforceable checks, but repository settings must also be configured in GitHub. Treat this file as the configuration checklist for `Settings`.
+
+## Code security
+
+Enable all features available for the repository:
+
+- Dependency graph
+- Dependabot alerts
+- Dependabot security updates
+- Private vulnerability reporting
+- Secret scanning
+- Push protection for secrets
+- Code scanning alerts
+
+This repository uses advanced CodeQL setup in `.github/workflows/codeql.yml`. Do not enable CodeQL default setup at the same time.
+
+## Required checks for `develop`
+
+Create a ruleset targeting `develop` and require:
+
+- `quality`
+- `container image (api)`
+- `container image (web)`
+- `integration`
+- `demo-journey`
+- `dependency-review`
+- `codeql (javascript-typescript)`
+- `codeql (actions)`
+
+Also require a pull request, at least one approval, dismissal of stale approvals, approval after the latest reviewable push, resolved conversations, and block force pushes and deletion. Do not grant routine administrator bypass.
+
+## Required checks for `main`
+
+Require the same checks as `develop`, plus:
+
+- `promotion-policy`
+- successful staging deployment checks from Railway
+
+Only merge `develop` into `main`. Use a merge commit for this promotion so the tested commit ancestry is retained. Do not squash or rebase the production promotion PR.
+
+## GitHub Actions policy
+
+- Default workflow token permissions should be read-only.
+- Do not allow GitHub Actions to create or approve pull requests unless a documented workflow requires it.
+- Restrict third-party actions and keep every action pinned to a full commit SHA.
+- Require review for changes under `.github/workflows/`.
+
+## Deployment environments
+
+Create separate GitHub environments named `staging` and `production`.
+
+- `staging` may deploy only from `develop`.
+- `production` may deploy only from `main` or protected release tags.
+- Require a reviewer for production and prevent self-review.
+- Do not allow administrators to bypass production environment protection.
+- Keep environment secrets isolated; staging must never inherit production credentials.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,54 @@
+name: codeql
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyse:
+    name: codeql (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      contents: read
+      security-events: write
+      packages: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+          - actions
+
+    steps:
+      - name: Check out the commit under analysis
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Initialise CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
+
+      - name: Analyse and publish SARIF
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,12 @@ on:
     branches:
       - main
       - develop
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - ready_for_review
   schedule:
     - cron: "17 4 * * 1"
   workflow_dispatch:
@@ -23,6 +29,7 @@ concurrency:
 jobs:
   analyse:
     name: codeql (${{ matrix.language }})
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,27 @@
+name: dependency-review
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: dependency-review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: never

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
       - develop
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - ready_for_review
 
 permissions:
   contents: read

--- a/.github/workflows/promotion-policy.yml
+++ b/.github/workflows/promotion-policy.yml
@@ -1,0 +1,37 @@
+name: promotion-policy
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  promotion-policy:
+    name: promotion-policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Require same-repository develop source
+        env:
+          HEAD_BRANCH: ${{ github.head_ref }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          TARGET_REPOSITORY: ${{ github.repository }}
+        run: |
+          if [ "$HEAD_REPOSITORY" != "$TARGET_REPOSITORY" ]; then
+            echo "::error::Production promotions must originate from this repository."
+            exit 1
+          fi
+
+          if [ "$HEAD_BRANCH" != "develop" ]; then
+            echo "::error::Pull requests into main must originate from develop."
+            exit 1
+          fi

--- a/.github/workflows/promotion-policy.yml
+++ b/.github/workflows/promotion-policy.yml
@@ -8,6 +8,7 @@ on:
       - opened
       - reopened
       - synchronize
+      - edited
       - ready_for_review
 
 permissions:


### PR DESCRIPTION
## What changed and why

Adds the repository-side security and promotion controls identified in the GitHub configuration audit.

- Adds advanced CodeQL analysis for JavaScript/TypeScript and GitHub Actions.
- Publishes CodeQL SARIF findings to GitHub code scanning on pull requests, pushes, weekly schedules, and manual runs.
- Uses the extended security and security-and-quality query suites.
- Adds dependency review to block pull requests that introduce high or critical vulnerable dependencies.
- Adds a production promotion check that only accepts same-repository `develop` → `main` pull requests.
- Documents the GitHub settings, required checks, branch rulesets, Actions policy, and deployment-environment protections that cannot be configured through repository files.
- Pins all added actions to full commit SHAs and grants only the permissions each workflow requires.

## How it was verified

The initial workflow run showed that the security workflows themselves passed:

- `ci`: passed
- `codeql`: passed
- `dependency-review`: passed

The only failure was `promotion-policy`, because the PR originally targeted `main` from a feature branch. The repository now has `develop`, so this PR has been retargeted to `develop`. A follow-up documentation commit triggered fresh checks without weakening the production policy.

The workflows use pinned releases:

- `github/codeql-action` v4.37.6
- `actions/dependency-review-action` v5.0.0
- the repository's existing pinned `actions/checkout` v7.0.1

CodeQL results will appear under Security → Code scanning after the workflow uploads SARIF.

## Repository settings still required

After merging:

1. Enable secret scanning and push protection.
2. Enable dependency graph, Dependabot alerts/security updates, private vulnerability reporting, and code scanning alerts.
3. Do not enable CodeQL default setup; this PR installs advanced setup.
4. Configure the `develop` and `main` rulesets using the required check names in `.github/SECURITY_CONFIGURATION.md`.
5. Configure separate `staging` and `production` environments and Railway deployment checks.
6. Add a second trusted reviewer and a `CODEOWNERS` file before requiring Code Owner approval.

## Checks that this repository cares about

- [x] No application route or authorisation behaviour changed.
- [x] No new public endpoint was added.
- [x] No database migration was added.
- [x] No secret is written to logs or reports.
- [x] Third-party actions are pinned to immutable commit SHAs.
- [x] Workflow token permissions follow least privilege.
- [x] Configuration that must be applied outside the repository is documented explicitly.

## Anything a reviewer should look at hardest

The promotion workflow is intentionally narrow: only a same-repository pull request whose head branch is exactly `develop` may target `main`. Feature and maintenance PRs, including this one, must target `develop` first.